### PR TITLE
Layer containing unresolved reviews get's loaded twice in UI

### DIFF
--- a/js/hoot/tools.js
+++ b/js/hoot/tools.js
@@ -526,14 +526,24 @@ Hoot.tools = function (context, selection) {
                                         	iD.ui.Alert("Could not determine input layer 1. It will not be loaded.",'warning');
                                         }
                                     }
+                                } else {
+                                    var doRenderView = true;
+                                    if(params['hideinsidebar'] !== undefined && params['hideinsidebar'] === 'true'){
+                                        doRenderView = false;
+                                    }
+
+                                    if(doRenderView === true){
+                                        renderInputLayer(layerName,params);
+                                    } else {
+                                        loadedLayers[layerName] = params;
+                                        loadedLayers[layerName].loadable = true;
+                                        loadingLayer = {};
+                                    } 
                                 }
                             }
                         });
                     }
-                }
-
-                if(isReviewMode === false) {
-
+                } else {
                     var doRenderView = true;
                     if(params['hideinsidebar'] !== undefined && params['hideinsidebar'] === 'true'){
                         doRenderView = false;
@@ -545,9 +555,8 @@ Hoot.tools = function (context, selection) {
                         loadedLayers[layerName] = params;
                         loadedLayers[layerName].loadable = true;
                         loadingLayer = {};
-                    }
+                    }                    
                 }
-
             });
 
 


### PR DESCRIPTION
* ngageoint/hootenanny-ui#253

Changed the 'if statement' to assume that if there are no active reviews, there is no reason to go into review mode.  It seemed that there were times where the code would jump to this statement before the user could determine if they wanted to go into review mode.  If the user does not decide to go into review mode, the same code is run.  

This is a duplication (lines 531-540 and 547-557) and can be adjusted, but wanted to get this fixed before cutting the release.  Will also push into release branch once this pull request is closed.