### PR TITLE
#518: Disable the locator overlay when switching away from Satellite imagery

### DIFF
--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -30,7 +30,7 @@ iD.Background = function(context) {
     //Added to remove the Locator Overlay layer on layers that have their own labels on 
     //the initial launch of the map
     function checkLocatorNeed(locatorNeed){
-        if (locatorNeed == "MAPNIK" || locatorNeed == "USGS Topographic Maps"){
+        if (locatorNeed === 'MAPNIK' || locatorNeed === 'USGS Topographic Maps'){
             return false;
         } else{
             return true;

--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -27,6 +27,15 @@ iD.Background = function(context) {
         });
     }
 
+    //Added to remove the Locator Overlay layer on layers that have their own labels
+    function checkLocatorNeed(locatorNeed){
+        if (locatorNeed == "MAPNIK" || locatorNeed == "USGS Topographic Maps"){
+            return false;
+        } else{
+            return true;
+        }
+    }
+
     function updateImagery() {
         var b = background.baseLayerSource(),
             o = overlayLayers.map(function (d) { return d.source().id; }).join(','),
@@ -504,14 +513,14 @@ iD.Background = function(context) {
             return d.overlay && d.default;
         });
 
-        if (locator) {
+        if (checkLocatorNeed(background.baseLayerSource().imageryUsed())) {
             background.toggleOverlayLayer(locator);
         }
 
         var overlays = (q.overlays || '').split(',');
         overlays.forEach(function(overlay) {
             overlay = findSource(overlay);
-            if (overlay) background.toggleOverlayLayer(overlay);
+            // if (overlay) background.toggleOverlayLayer(overlay);
         });
 
         // var gpx = q.gpx;

--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -27,7 +27,8 @@ iD.Background = function(context) {
         });
     }
 
-    //Added to remove the Locator Overlay layer on layers that have their own labels
+    //Added to remove the Locator Overlay layer on layers that have their own labels on 
+    //the initial launch of the map
     function checkLocatorNeed(locatorNeed){
         if (locatorNeed == "MAPNIK" || locatorNeed == "USGS Topographic Maps"){
             return false;

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -79,8 +79,8 @@ iD.ui.Background = function(context) {
                 .sources(context.map().extent())
                 .filter(function(d) { return d.overlay;});
 
-            var layerUsed = d.imageryUsed()
-            if (layerUsed == "MAPNIK" || layerUsed == "USGS Topographic Maps"){
+            var layerUsed = d.imageryUsed();
+            if (layerUsed === 'MAPNIK' || layerUsed === 'USGS Topographic Maps'){
                 if (checkbox.classed('active')){
                     context.background().hideOverlayLayer(overlays[0]);
                 } else {
@@ -96,7 +96,7 @@ iD.ui.Background = function(context) {
         function clickSetSource(d) {
             d3.event.preventDefault();
             context.background().baseLayerSource(d);
-            checkLocatorOverlay(d3.select("#locator_overlay"), d)
+            checkLocatorOverlay(d3.select('#locator_overlay'), d);
             selectLayer();
 
             //Added to zoom to imported basemap

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -73,6 +73,7 @@ iD.ui.Background = function(context) {
             //collections.classed('hide', true);
         }
 
+        //Added for toggling the overlay labels on and off when the layer changes
         function checkLocatorOverlay(checkbox, d){
             var overlays = context.background()
                 .sources(context.map().extent())

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -126,6 +126,9 @@ iD.ui.Background = function(context) {
                 .filter(filter);
 
             var layerLinks = layerList.selectAll('li.layer')
+                .attr('id', function(d){
+                    return d.imageryUsed().replace(/ /g, '_').toLowerCase();
+                })
                 .data(sources, function(d) { return d.name(); })
                 .sort(sortSources); //added for iD v1.9.2
 

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -73,9 +73,29 @@ iD.ui.Background = function(context) {
             //collections.classed('hide', true);
         }
 
+        function checkLocatorOverlay(checkbox, d){
+            var overlays = context.background()
+                .sources(context.map().extent())
+                .filter(function(d) { return d.overlay;});
+
+            var layerUsed = d.imageryUsed()
+            if (layerUsed == "MAPNIK" || layerUsed == "USGS Topographic Maps"){
+                if (checkbox.classed('active')){
+                    context.background().hideOverlayLayer(overlays[0]);
+                } else {
+                    return;
+                }
+            } else {
+                if (!checkbox.classed('active')){
+                    context.background().showOverlayLayer(overlays[0]);
+                }
+            }
+        }
+
         function clickSetSource(d) {
             d3.event.preventDefault();
             context.background().baseLayerSource(d);
+            checkLocatorOverlay(d3.select("#locator_overlay"), d)
             selectLayer();
 
             //Added to zoom to imported basemap


### PR DESCRIPTION
This turns on/off the labels layer when it is needed/not necessary. Users can still manually toggle it on/off if they would like.

Ticket: #518 