### PR TITLE
No Translation option for OSM Export Format

### DIFF
--- a/js/hoot/control/Export.js
+++ b/js/hoot/control/Export.js
@@ -147,6 +147,7 @@ Hoot.control.export = function (context, sidebar) {
                         
                         d3.select(this)
                         .on('change',function(){
+                            checkForOSM();
                             checkForTemplate();
                         });
                     }
@@ -195,16 +196,40 @@ Hoot.control.export = function (context, sidebar) {
                 event.saveLayer(save, layer);
             });
          });
+
+        function checkForOSM(){
+            var container = d3.select('#sidebar2');
+            var exportType = container.select('#fileExportFileType').value();
+            var transCombobox = container.select('#fileExportTranslation').data()[0].combobox;
+            var transData = transCombobox.data;
+
+            if(exportType !== 'Open Street Map (OSM)'){ 
+                // Remove 'No Translation' from Translation options            
+                transData = _.without(transCombobox.data,_.find(transCombobox.data,{'NAME':'None'}));
+            } else {
+                transData.push({'DESCRIPTION':'No Translation','NAME':'None'});
+            }
+
+            var combo = d3.combobox()
+            .data(_.map(transData, function (n) {
+                return {
+                    value: n.DESCRIPTION,
+                    title: n.DESCRIPTION
+                };
+            }));
+            container.select('#fileExportTranslation').style('width','100%').call(combo);            
+        }
         
         function checkForTemplate(){
             var hidden=false;
 
-            var exportType = d3.select('.fileExportFileType').value();
-            var transType = d3.select('.fileExportTranslation').value();
+            var container = d3.select('#sidebar2');
+            var exportType = container.select('.fileExportFileType').value();
+            var transType = container.select('.fileExportTranslation').value();
 
             // Check if output type is File Geodatabase
-            if (exportType===''){exportType=d3.select('.fileExportFileType').attr('placeholder');}
-            if (transType===''){transType=d3.select('.fileExportTranslation').attr('placeholder');}
+            if (exportType===''){exportType=container.select('.fileExportFileType').attr('placeholder');}
+            if (transType===''){transType=container.select('.fileExportTranslation').attr('placeholder');}
 
             if(exportType!=='File Geodatabase'){
                 hidden=true;
@@ -219,9 +244,9 @@ Hoot.control.export = function (context, sidebar) {
                 hidden=true;
             }
 
-            d3.select('.cboxAppendFGDBTemplate').classed('hidden',hidden);
+            container.select('.cboxAppendFGDBTemplate').classed('hidden',hidden);
             if(hidden){
-                d3.select('.cboxAppendFGDBTemplate').select('input').property('checked',false);
+                container.select('.cboxAppendFGDBTemplate').select('input').property('checked',false);
             }
         }
 

--- a/js/hoot/control/utilities/ExportDataset.js
+++ b/js/hoot/control/utilities/ExportDataset.js
@@ -200,7 +200,7 @@ Hoot.control.utilities.exportdataset = function(context) {
             };
         }));
         container.select('#fileExportTranslation').style('width','100%').call(combo);            
-    }
+    };
 
     /**
     * @desc Toggler for Append to ESRI FGDB Template checkbox.

--- a/js/hoot/control/utilities/ExportDataset.js
+++ b/js/hoot/control/utilities/ExportDataset.js
@@ -171,9 +171,36 @@ Hoot.control.utilities.exportdataset = function(context) {
 
         d3.select(this)
             .on('change',function(){
+                _checkForOSM();
                 _checkForTemplate();
             });
     };
+
+    /**
+    * @desc Toggler for adding None Translation if OSM is selected output
+    **/
+    var _checkForOSM = function(){
+        var container = d3.select('.hoot-menu');
+        var exportType = container.select('#fileExportFileType').value();
+        var transCombobox = container.select('#fileExportTranslation').data()[0].combobox;
+        var transData = transCombobox.data;
+
+        if(exportType !== 'Open Street Map (OSM)'){ 
+            // Remove 'No Translation' from Translation options            
+            transData = _.without(transCombobox.data,_.find(transCombobox.data,{'NAME':'None'}));
+        } else {
+            transData.push({'DESCRIPTION':'No Translation','NAME':'None'});
+        }
+
+        var combo = d3.combobox()
+        .data(_.map(transData, function (n) {
+            return {
+                value: n.DESCRIPTION,
+                title: n.DESCRIPTION
+            };
+        }));
+        container.select('#fileExportTranslation').style('width','100%').call(combo);            
+    }
 
     /**
     * @desc Toggler for Append to ESRI FGDB Template checkbox.
@@ -181,12 +208,13 @@ Hoot.control.utilities.exportdataset = function(context) {
     var _checkForTemplate = function(){
         var hidden=false;
 
-        var exportType = d3.select('#fileExportFileType').value();
-        var transType = d3.select('#fileExportTranslation').value();
+        var container = d3.select('.hoot-menu');
+        var exportType = container.select('#fileExportFileType').value();
+        var transType = container.select('#fileExportTranslation').value();
 
         // Check if output type is File Geodatabase
-        if (exportType===''){exportType=d3.select('#fileExportFileType').attr('placeholder');}
-        if (transType===''){transType=d3.select('#fileExportTranslation').attr('placeholder');}
+        if (exportType===''){exportType=container.select('#fileExportFileType').attr('placeholder');}
+        if (transType===''){transType=container.select('#fileExportTranslation').attr('placeholder');}
 
         if(exportType!=='File Geodatabase'){
          hidden=true;
@@ -201,9 +229,9 @@ Hoot.control.utilities.exportdataset = function(context) {
          hidden=true;
         }
 
-        d3.select('.cboxAppendFGDBTemplate').classed('hidden',hidden);
+        container.select('.cboxAppendFGDBTemplate').classed('hidden',hidden);
         if(hidden){
-         d3.select('.cboxAppendFGDBTemplate').select('input').property('checked',false);
+            container.select('.cboxAppendFGDBTemplate').select('input').property('checked',false);
         }
     };
 

--- a/js/hoot/model/Export.js
+++ b/js/hoot/model/Export.js
@@ -86,7 +86,8 @@ Hoot.model.export = function (context)
         param.translation = selectedTranslation;
         //OSM API db override - Datasets are written to an OSM API database as OSM, so translation 
         //is ignored here.
-        if (selectedOutType === 'osm_api_db')
+        //Do the same if selected translation is "None"
+        if (selectedOutType === 'osm_api_db' || oTrans.NAME === 'None')
         {
             param.translation = 'NONE';
         }


### PR DESCRIPTION
Also noticed that if 2 export dialogs are open, can override.  Added container variable to capture that in the rare occurrence it happens.

Issue #521 