### PR TITLE
508

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2036,6 +2036,11 @@ div.full-screen > button:hover {
     text-overflow: ellipsis;
 }
 
+.layer-list-hidden{
+    display: none;
+    border: none;
+}
+
 .minimap-toggle {
     display: block;
     padding: 5px 10px;

--- a/css/app.css
+++ b/css/app.css
@@ -1972,8 +1972,16 @@ div.full-screen > button:hover {
 
 .layer-list, .controls-list {
     margin-bottom: 10px;
-    border: 1px solid #CCC;
+    border-top: 1px;
+    border-right: 1px;
+    border-left: 1px;
+    border-style: solid;
+    border-color: #CCC;
     border-radius: 4px;
+}
+
+.controls-list{
+    border-bottom: 1px solid #ccc;
 }
 
 .layer-list li {
@@ -1993,13 +2001,15 @@ div.full-screen > button:hover {
 
 .layer-list > li:last-child {
     border-radius: 0 0 3px 3px;
+    border-bottom: 1px solid #ccc;
 }
 
 .layer-list > li:only-child {
     border-radius: 3px;
+    border-bottom: 1px solid #ccc;
 }
 
-.layer-list li:not(:last-child) {
+.layer-list > li:not(:last-child) {
     border-bottom: 1px solid #ccc;
 }
 

--- a/css/app.css
+++ b/css/app.css
@@ -1970,6 +1970,10 @@ div.full-screen > button:hover {
     padding-bottom: 10px;
 }
 
+.layer-browse{
+    width: 10%;
+}
+
 .layer-list, .controls-list {
     margin-bottom: 10px;
     border-top: 1px;
@@ -2185,7 +2189,7 @@ div.full-screen > button:hover {
 .background-control .layer-list button {
     float: right;
     height: 100%;
-    width: 10%;
+    /*width: 10%;*/
     border-left: 1px solid #CCC;
     border-radius: 0;
 }

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -196,12 +196,12 @@ iD.ui.Background = function(context) {
 
             var layerIds = _.pluck(context.hoot().model.layers.getLayers(), 'id');
             if (layerIds.length > 0){
-                var overlayParent = overlayList.node()
-                var overlayLayers = overlayList.selectAll('li.layer')
+                // var overlayParent = overlayList.node()
+                var overlayLayers = overlayList.selectAll('li.layer');
                 for (var i=0; i<overlayLayers[0].length; i++){
                     if (parseInt(overlayLayers[0][i].id)){
-                        var item = d3.select(overlayLayers[0][i])
-                        item.classed('layer-list-hidden', true)
+                        var item = d3.select(overlayLayers[0][i]);
+                        item.classed('layer-list-hidden', true);
                     }
                 }
             }

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -194,6 +194,7 @@ iD.ui.Background = function(context) {
             backgroundList.call(drawList, 'radio', clickSetSource, function(d) { return !d.overlay; });
             overlayList.call(drawList, 'checkbox', clickSetOverlay, function(d) { return d.overlay; });
 
+            var layerIds = _.pluck(context.hoot().model.layers.getLayers(), 'id');
             selectLayer();
 
             var source = context.background().baseLayerSource();

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -198,6 +198,12 @@ iD.ui.Background = function(context) {
             if (layerIds.length > 0){
                 var overlayParent = overlayList.node()
                 var overlayLayers = overlayList.selectAll('li.layer')
+                for (var i=0; i<overlayLayers[0].length; i++){
+                    if (parseInt(overlayLayers[0][i].id)){
+                        var item = d3.select(overlayLayers[0][i])
+                        item.classed('layer-list-hidden', true)
+                    }
+                }
             }
             selectLayer();
 

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -195,6 +195,10 @@ iD.ui.Background = function(context) {
             overlayList.call(drawList, 'checkbox', clickSetOverlay, function(d) { return d.overlay; });
 
             var layerIds = _.pluck(context.hoot().model.layers.getLayers(), 'id');
+            if (layerIds.length > 0){
+                var overlayParent = overlayList.node()
+                var overlayLayers = overlayList.selectAll('li.layer')
+            }
             selectLayer();
 
             var source = context.background().baseLayerSource();


### PR DESCRIPTION
Layers now are hidden from view in the `layer-list`, but users can still interact with them in the `hoot-layers`.

I also, added [this code](https://github.com/ngageoint/hootenanny-ui/commit/8a76ec3a0ab96ea39b0fb424f6fd5c4f64346ac4) to fix the arrows looking off center in the `hoot-layers` list. Can easily be changed back if it's not the desired look. 

Ticket: #508 