### PR TITLE
466

### DIFF
--- a/js/hoot/control/Import.js
+++ b/js/hoot/control/Import.js
@@ -72,11 +72,20 @@ Hoot.control.import = function (context,selection) {
             .on('click', function () {toggleForm(this);});
         var fieldset = _form.append('fieldset');
         fieldset.classed('pad1 keyline-left keyline-right keyline-bottom round-bottom hidden', true)
+            .attr('id', function(){
+                var pnode = d3.select(d3.select(this).node().parentNode);
+                if(isPrimary || pnode.node().nextSibling){return 'refDataset';}
+                else {return 'secondaryDataset';}
+            })
             .selectAll('.form-field')
             .data(d_form)
             .enter()
             .append('div')
-            .classed('overflow',true)
+            .attr('class', function(){
+                var pnode = d3.select(d3.select(this).node().parentNode);
+                if(pnode.attr('id') === 'refDataset'){return 'overflow svgLayerList refDataset';}
+                else {return 'overflow svgLayerList secondaryDataset';}
+            })
             .style({'height':'150px','margin':'0 0 15px','resize':'vertical'})
             .select(ETL.renderTree);
         

--- a/js/hoot/control/Import.js
+++ b/js/hoot/control/Import.js
@@ -68,7 +68,7 @@ Hoot.control.import = function (context,selection) {
                 var pnode = d3.select(d3.select(this).node().parentNode);
                 if(isPrimary || pnode.node().nextSibling){return 'Add Reference Dataset';}
                 else {return 'Add Secondary Dataset';}
-                })
+            })
             .on('click', function () {toggleForm(this);});
         var fieldset = _form.append('fieldset');
         fieldset.classed('pad1 keyline-left keyline-right keyline-bottom round-bottom hidden', true)

--- a/js/hoot/control/utilities/Folder.js
+++ b/js/hoot/control/utilities/Folder.js
@@ -144,6 +144,10 @@ Hoot.control.utilities.folder = function(context) {
             // Compute the flattened node list. TODO use d3.layout.hierarchy.
               var nodes = tree.nodes(root);
 
+              if(container.classed('secondaryDataset')){
+                nodes = _.without(nodes, _.find(nodes, {id:-1}));
+              }
+
               var height = Math.max(150, nodes.length * barHeight + margin.top + margin.bottom);
 
               //replaced container with d3


### PR DESCRIPTION
An ID and class gets added to the `fieldset` tag and if the class is equal to `secondaryDataset`, underscore with remove anything with a -1 ID (in this case, the Mapedit DB layer)

I noticed at one point the ID wasn't adding correctly, but I wasn't able to recreate it. If it comes out in testing, I will work on recreating/fixing it.

Ticket: #466 