### PR TITLE
588 - Prompt users to finish drawing before deleting a layer

### DIFF
--- a/js/hoot/control/View.js
+++ b/js/hoot/control/View.js
@@ -107,7 +107,7 @@ Hoot.control.view = function (container, context) {
                     d3.event.preventDefault();
 
                     if (context.mode().id === 'add-point' || context.mode().id === 'draw-line' || context.mode().id === 'draw-area'){
-                        alert('Sorry, this is not allowed while editing. Please finish drawing your line or area, then delete the layer');
+                        iD.ui.Alert('Sorry, this is not allowed while editing. Please finish drawing your line or area, then delete the layer', 'error', new Error().stack);
                         return;
                     }
 

--- a/js/hoot/control/View.js
+++ b/js/hoot/control/View.js
@@ -106,7 +106,7 @@ Hoot.control.view = function (container, context) {
                     d3.event.stopPropagation();
                     d3.event.preventDefault();
 
-                    if (context.mode().id === 'draw-line' || context.mode().id === 'draw-area'){
+                    if (context.mode().id === 'add-point' || context.mode().id === 'draw-line' || context.mode().id === 'draw-area'){
                         alert('Sorry, this is not allowed while editing. Please finish drawing your line or area, then delete the layer');
                         return;
                     }

--- a/js/hoot/control/View.js
+++ b/js/hoot/control/View.js
@@ -106,6 +106,11 @@ Hoot.control.view = function (container, context) {
                     d3.event.stopPropagation();
                     d3.event.preventDefault();
 
+                    if (context.mode().id === 'draw-line' || context.mode().id === 'draw-area'){
+                        alert('Sorry, this is not allowed while editing. Please finish drawing your line or area, then delete the layer')
+                        return;
+                    }
+
                     var primaryLayerName = '';
                     var sels = d3.select(form.node().parentNode).selectAll('form')[0];
                     if(sels && sels.length > 0){

--- a/js/hoot/control/View.js
+++ b/js/hoot/control/View.js
@@ -107,7 +107,7 @@ Hoot.control.view = function (container, context) {
                     d3.event.preventDefault();
 
                     if (context.mode().id === 'draw-line' || context.mode().id === 'draw-area'){
-                        alert('Sorry, this is not allowed while editing. Please finish drawing your line or area, then delete the layer')
+                        alert('Sorry, this is not allowed while editing. Please finish drawing your line or area, then delete the layer');
                         return;
                     }
 


### PR DESCRIPTION
If a user is in the `draw-line` or `draw-area` mode, they will be prompted when clicking the trash can icon to finish their drawing before deleting the layer.

Ticket: #588