### PR TITLE
Give variable to context.flush() in connection.js

### DIFF
--- a/js/id/core/connection.js
+++ b/js/id/core/connection.js
@@ -956,7 +956,7 @@ iD.Connection = function(context, useHttps) {
             if(currShowBbox !== lastShowBBox){
 
                 //doFlush = true;
-                context.flush();
+                context.flush(!context.history().hasChanges());
 
             }
 


### PR DESCRIPTION
Add code to prevent features from disappearing. If all works as planned, then if you draw a feature, then zoom in past z16, then zoom out, the feature should still be there. Workflow can be found [here](https://github.com/ngageoint/hootenanny-ui/issues/546).

Ticket: https://github.com/ngageoint/hootenanny-ui/issues/546