### PR TITLE
#586 added tooltips for translation descriptions

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2938,6 +2938,7 @@ div.full-screen > button:hover {
 .tooltip-inner {
     display: inline-block;
     border-radius: 3px;
+    max-width: 200px;
     min-width: 80px;
     padding: 10px;
     font-weight: normal;

--- a/css/app.css
+++ b/css/app.css
@@ -2906,6 +2906,7 @@ div.full-screen > button:hover {
     color:#333;
     text-align: left;
     font-size: 12px;
+    width: 400px;
 }
 
 .tooltip.in {
@@ -2937,7 +2938,7 @@ div.full-screen > button:hover {
 .tooltip-inner {
     display: inline-block;
     border-radius: 3px;
-    max-width: 200px;
+    max-width: 400px;
     min-width: 80px;
     padding: 10px;
     font-weight: normal;

--- a/css/app.css
+++ b/css/app.css
@@ -2906,7 +2906,6 @@ div.full-screen > button:hover {
     color:#333;
     text-align: left;
     font-size: 12px;
-    width: 400px;
 }
 
 .tooltip.in {
@@ -2935,10 +2934,10 @@ div.full-screen > button:hover {
     text-align: right;
 }
 
+
 .tooltip-inner {
     display: inline-block;
     border-radius: 3px;
-    max-width: 400px;
     min-width: 80px;
     padding: 10px;
     font-weight: normal;
@@ -3045,7 +3044,14 @@ div.full-screen > button:hover {
     font-weight: bold;
 }
 
+
 /* Exceptions for tooltip layouts */
+
+/* make tooltips for translations descriptions wider */
+
+.transl .tooltip {
+    width: 500px;
+}
 
 /* make tooltips in panels dark */
 .map-overlay .tooltip.top .tooltip-arrow,

--- a/js/hoot/view/utilities/Translation.js
+++ b/js/hoot/view/utilities/Translation.js
@@ -41,16 +41,27 @@ Hoot.view.utilities.translation = function(context) {
                 var tla2 = tla.append('div')
                     .classed('col12 fill-white small keyline-bottom', true);
                 var tla3 = tla2.append('span')
-                    .classed('text-left big col12 fill-white small hoverDiv2', true)
+                    .classed('text-left big col12 fill-white small hoverDiv2 pad1x', true)
                     .append('a')
+                    .style('position', 'relative')
+                    .style('top', '20px')
                     .text(function (d) {
                         if(d.DEFAULT === true){
-                            return d.NAME + ': ' + d.DESCRIPTION;
+                            return d.NAME;      
                         }
-                        return d.NAME + ': ' + d.DESCRIPTION;
+                        return d.NAME; 
+                    });
+                var tooltip = bootstrap.tooltip()
+                    .placement('right')
+                    .html('true')
+                    .title(function (d) {
+                        if(d.DEFAULT === true){
+                            return d.DESCRIPTION;      
+                        }
+                        return d.DESCRIPTION; 
                     });
 
-
+                    d3.selectAll('a').call(tooltip);
 
                 tla3.append('button')
                 //.classed('keyline-left keyline-right fr _icon trash pad2 col1', true)
@@ -91,7 +102,7 @@ Hoot.view.utilities.translation = function(context) {
                 .select(function (sel) {
                     if(sel.DEFAULT === true){
 
-                        d3.select(this).classed('keyline-left keyline-right fr _icon quiet trash pad2 col1', true);
+                        d3.select(this).classed('keyline-left keyline-right fr _icon trash pad2 col1', true);
                         d3.select(this).on('click', function () {
                             d3.event.stopPropagation();
                             d3.event.preventDefault();

--- a/js/hoot/view/utilities/Translation.js
+++ b/js/hoot/view/utilities/Translation.js
@@ -41,8 +41,10 @@ Hoot.view.utilities.translation = function(context) {
                 var tla2 = tla.append('div')
                     .classed('col12 fill-white small keyline-bottom', true);
                 var tla3 = tla2.append('span')
+                    /*.attr('.transl')*/
                     .classed('text-left big col12 fill-white small hoverDiv2 pad1x', true)
                     .append('a')
+                    .classed('transl', true)
                     .style('position', 'relative')
                     .style('top', '20px')
                     .text(function (d) {
@@ -61,7 +63,7 @@ Hoot.view.utilities.translation = function(context) {
                         return d.DESCRIPTION; 
                     });
 
-                    d3.selectAll('a').call(tooltip);
+                    d3.selectAll('a.transl').call(tooltip);
 
                 tla3.append('button')
                 //.classed('keyline-left keyline-right fr _icon trash pad2 col1', true)


### PR DESCRIPTION
On translations page you should see just the shortname of the translation and a tooltip of the description / longer name when you hover.

For some reason setting the opacity is bumping down the trashcan icon. I removed it for now. Not sure if it's necessary (or having a trashcan is necessary? I'm not sure if there's a case in which someone would choose to remove a translation). If we want to make the trashcans more transparent again I can look further into this.