### PR TITLE
623 Fixed borders in help menu

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2279,7 +2279,7 @@ div.full-screen > button:hover {
     border-radius: 4px 4px 0 0;
 }
 
-.help-wrap .toc li:nth-last-child(2) a {
+.help-wrap .toc li:last-child a {
     border-bottom: 1px solid #CCC;
     border-radius: 0 0 4px 4px
 }


### PR DESCRIPTION
This is the change

Before:
![screenshot from 2016-08-03 10 51 20](https://cloud.githubusercontent.com/assets/17434033/17370056/9e707630-5968-11e6-85d4-61e2a5c68673.png)

After:
![screenshot from 2016-08-03 10 51 00](https://cloud.githubusercontent.com/assets/17434033/17370053/9cea4156-5968-11e6-9589-d8a4ca83866f.png)

(#623)
