### PR TITLE
#560 Removing shadow on map move

### DIFF
--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -190,7 +190,8 @@ iD.Map = function(context) {
 
         d3.selectAll('.vertex').remove();
         //d3.selectAll('.shadow').remove();
-        d3.selectAll('path.shadow:not(.activeReviewFeature):not(.activeReviewFeature2)').remove();
+        var linesContainer = d3.select('.layer-lines');
+        linesContainer.selectAll('path.shadow:not(.activeReviewFeature):not(.activeReviewFeature2):not(.unsaved)').remove();
 
         surface
             .call(drawVertices, graph, data, filter, map.extent(), map.zoom())
@@ -798,7 +799,8 @@ iD.Map = function(context) {
 
         d3.selectAll('.vertex').remove();
         //d3.selectAll('.shadow').remove();
-        d3.selectAll('path.shadow:not(.activeReviewFeature):not(.activeReviewFeature2)').remove();
+        var linesContainer = d3.select('.layer-lines');
+        linesContainer.selectAll('path.shadow:not(.activeReviewFeature):not(.activeReviewFeature2):not(.unsaved)').remove();
 
         var farLine = iD.svg.FarLine(projection, context);
         var farArea = iD.svg.FarArea(projection, context);

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -189,7 +189,7 @@ iD.Map = function(context) {
             data = features.filter(data, graph);
 
         d3.selectAll('.vertex').remove();
-        //d3.selectAll('.shadow').remove();
+        d3.selectAll('.shadow').remove();
 
         surface
             .call(drawVertices, graph, data, filter, map.extent(), map.zoom())
@@ -796,7 +796,7 @@ iD.Map = function(context) {
         data = features.filter(data, graph);
 
         d3.selectAll('.vertex').remove();
-        //d3.selectAll('.shadow').remove();
+        d3.selectAll('.shadow').remove();
 
         var farLine = iD.svg.FarLine(projection, context);
         var farArea = iD.svg.FarArea(projection, context);

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -189,7 +189,8 @@ iD.Map = function(context) {
             data = features.filter(data, graph);
 
         d3.selectAll('.vertex').remove();
-        d3.selectAll('.shadow').remove();
+        //d3.selectAll('.shadow').remove();
+        d3.selectAll('path.shadow:not(.activeReviewFeature):not(.activeReviewFeature2)').remove();
 
         surface
             .call(drawVertices, graph, data, filter, map.extent(), map.zoom())
@@ -796,7 +797,8 @@ iD.Map = function(context) {
         data = features.filter(data, graph);
 
         d3.selectAll('.vertex').remove();
-        d3.selectAll('.shadow').remove();
+        //d3.selectAll('.shadow').remove();
+        d3.selectAll('path.shadow:not(.activeReviewFeature):not(.activeReviewFeature2)').remove();
 
         var farLine = iD.svg.FarLine(projection, context);
         var farArea = iD.svg.FarArea(projection, context);


### PR DESCRIPTION
#560 

By removing the shadow class on map move, the delayed shadow drawing no longer occurs.  This line had been commented out, but cannot find supporting evidence as to why.