### PR TITLE
Map now re-renders when window is resized.

### DIFF
--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -543,7 +543,13 @@ iD.Map = function(context) {
         if (!arguments.length) return dimensions;
         var center = map.center();
         dimensions = _;
-        //drawLayers replaced surface in iD v1.9.2
+        // drawLayers replaced surface in iD v1.9.2
+        window.addEventListener('resize', refresh);
+        function refresh() {
+            dimensions[0] = window.innerWidth; //400 subtracted for sidebar
+            dimensions[1] = window.innerHeight;
+            console.log('refresh');
+        };
         drawLayers.dimensions(dimensions);
         context.background().dimensions(dimensions);
         projection.clipExtent([[0, 0], dimensions]);


### PR DESCRIPTION
When Hoot is opened in a minimized window, it should now scale accordingly when the window is maximized or dragged to the desired size.

Ticket: #538 