### PR TITLE
376

### DIFF
--- a/js/id/id.js
+++ b/js/id/id.js
@@ -37,7 +37,7 @@ window.iD = function () {
 
     /* Accessor for setting minimum zoom for editing features. */
 
-    var minEditableZoom = 0;
+    var minEditableZoom = 8;
     context.minEditableZoom = function(_) {
         if (!arguments.length) return minEditableZoom;
         minEditableZoom = _;

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -37,7 +37,7 @@ window.iD = function () {
 
     /* Accessor for setting minimum zoom for editing features. */
 
-    var minEditableZoom = 16;
+    var minEditableZoom = 0;
     context.minEditableZoom = function(_) {
         if (!arguments.length) return minEditableZoom;
         minEditableZoom = _;

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -237,7 +237,7 @@ iD.Map = function(context) {
             iD.ui.flash(context.container())
                 .select('.content')
                 .text(t('cannot_zoom'));
-            setZoom(context.minEditableZoom(), true);
+            setZoom(context.minEditableZoom() + 1, true);
             queueRedraw();
             dispatch.move(map);
             return;
@@ -632,7 +632,7 @@ iD.Map = function(context) {
         }
 
         if (z < minzoom) {
-            surface.interrupt();
+            // surface.interrupt();
             iD.ui.flash(context.container())
                 .select('.content')
                 .text(t('cannot_zoom'));

--- a/test/spec/renderer/map.js
+++ b/test/spec/renderer/map.js
@@ -33,9 +33,9 @@ describe('iD.Map', function() {
         });
 
         it('respects minzoom', function() {
-            map.minzoom(16);
-            map.zoom(15);
-            expect(map.zoom()).to.equal(16);
+            map.minzoom(8);
+            map.zoom(7);
+            expect(map.zoom()).to.equal(8);
         });
     });
 


### PR DESCRIPTION
Allows edits (such as drawing lines) to be made at any zoom level without error messages. It doesn't seem to affect the drawing of any features, but maybe someone else can break it.