### PR TITLE
627: context menu hanging

### DIFF
--- a/js/hoot/control/utilities/Folder.js
+++ b/js/hoot/control/utilities/Folder.js
@@ -389,14 +389,14 @@ Hoot.control.utilities.folder = function(context) {
 
                       // create the div element that will hold the context menu
                       d3.selectAll('.context-menu').data([1])
-                          .enter()
+                        .enter()
                         .append('div')
                         .attr('class', 'context-menu');
                       // close menu
                       d3.select('body').on('click.context-menu', function() {d3.select('.context-menu').style('display', 'none');});
                       // this gets executed when a contextmenu event occurs
                       d3.selectAll('.context-menu')
-                          .html('')
+                        .html('')
                         .append('ul')
                         .selectAll('li')
                         .data(items).enter()
@@ -442,6 +442,8 @@ Hoot.control.utilities.folder = function(context) {
                             context.hoot().model.layers.setSelectedLayers(selectedLayerIDs);
 
                             d3.select('.context-menu').remove();
+
+                              
                         })
                         .attr('class',function(item){return '_icon ' + item.icon;})
                         .text(function(item) { return item.title; });
@@ -453,6 +455,8 @@ Hoot.control.utilities.folder = function(context) {
                         .style('display', 'block');
                   //} else {d3.select('.context-menu').style('display', 'none');}
                   d3.event.preventDefault();
+
+
               });
           } else {container.selectAll('rect').on('contextmenu',function(){d3.event.preventDefault();});}
         }

--- a/js/hoot/view/utilities/Utilities.js
+++ b/js/hoot/view/utilities/Utilities.js
@@ -152,6 +152,7 @@ Hoot.view.utilities = function (context){
                     .text(txt);
                 d3.selectAll('#jobsBG')
                     .classed('hidden', vis);
+                d3.select('.context-menu').remove();
 
                 if(_activeSettingsTabId && _activeSettingsTabId === '#utilReviewBookmarks' && txt === 'Manage') {
                     context.hoot().view.utilities.reviewbookmarknotes.resetToList();


### PR DESCRIPTION
If you return to map with the context menu still up it should now disappear :dash:

**To repeat:** 
1. Open hoot, click on manage tab
2. Right click on a dataset, any dataset!
3. Click "Return to map." Context menu should go away.

See ngageoint/hootenanny-ui#627
