### PR TITLE
#741: fixes context menu hang for tools menu and bulk import

### DIFF
--- a/js/hoot/view/utilities/Utilities.js
+++ b/js/hoot/view/utilities/Utilities.js
@@ -152,7 +152,7 @@ Hoot.view.utilities = function (context){
                     .text(txt);
                 d3.selectAll('#jobsBG')
                     .classed('hidden', vis);
-                d3.select('.context-menu').remove();
+                d3.selectAll('.context-menu, .tools-menu, .dataset-options-menu').remove();
 
                 if(_activeSettingsTabId && _activeSettingsTabId === '#utilReviewBookmarks' && txt === 'Manage') {
                     context.hoot().view.utilities.reviewbookmarknotes.resetToList();


### PR DESCRIPTION
Extension of #627. 

Fixed context menu hanging for **Tools menu**:
1. Click tools, navigate over one of the options so the second menu pops up.
2. Click "Manage" button. Context menus should disappear.

and **Bulk Import**:
1. Click on "Manage" button.
2. On datasets menu, right click "Add Dataset" to show "Bulk Import" context menu.
3. Click "Return to Map." Context menu should disappear.
