### PR TITLE
Remove JS changes for tag table, adjust size of columns

### DIFF
--- a/css/hoot-style.css
+++ b/css/hoot-style.css
@@ -239,7 +239,7 @@ td.f2 {
     background: rgba(0, 0, 255, 0.5);
 }
 td.f1, td.f2 {
-    min-width: 25px;
+    min-width: 75px;
 }
 td.f1:hover, td.f2:hover {
   cursor: pointer;


### PR DESCRIPTION
So I widened the columns, they default to the width in the image below (75px) when there's no data in the tag table. Let me know if this looks better than "N/A" as a placeholder.

![screenshot from 2016-11-29 11 03 42](https://cloud.githubusercontent.com/assets/17727812/20717498/a9629ec0-b623-11e6-9ffa-fde09ef204ff.png)
