### PR TITLE
Check version Bug Fix with new logo

### DIFF
--- a/css/style2.css
+++ b/css/style2.css
@@ -161,7 +161,7 @@ input.round        { border-radius:4px; }
  }
 
 
-.hoot-logo {
+.hoot_label {
     background: url(img/logo/hoot_logo_update.png);
     background-repeat: no-repeat;
     background-position: 0 0;
@@ -521,7 +521,8 @@ table.map-metadata {
 }
 
 /*Hootenanny label*/
-.hoot_label{
+/* got rid of this when we added the new logo
+/*.hoot_label{
   height: 20px;
   line-height:20px;
   color: white;
@@ -529,7 +530,7 @@ table.map-metadata {
   padding-left: 5px;
   font-size: 20px;
   letter-spacing: -1px;
-}
+}*/
 
 /*Divider in label*/
 .divider{

--- a/js/hoot/view/utilities/Utilities.js
+++ b/js/hoot/view/utilities/Utilities.js
@@ -173,9 +173,8 @@ Hoot.view.utilities = function (context){
         var labelContainer = header.append('div');
 
         labelContainer.append('div')
-        .classed('point hoot-logo', true)
         .attr('href', '#version')
-        .append('img')
+        .classed('point hoot-logo', true)
         .attr('height', '60px')
         .on('click', function (){
              context.hoot().view.versioninfo.showPopup();

--- a/js/hoot/view/utilities/Utilities.js
+++ b/js/hoot/view/utilities/Utilities.js
@@ -174,7 +174,7 @@ Hoot.view.utilities = function (context){
 
         labelContainer.append('div')
         .attr('href', '#version')
-        .classed('point hoot-logo', true)
+        .classed('point hoot_label', true)
         .attr('height', '60px')
         .on('click', function (){
              context.hoot().view.versioninfo.showPopup();


### PR DESCRIPTION
When I added the new logo I did something silly which made the check version popup to not work.

So I fixed that, and changed the `hoot-logo` class to `hoot_label` so the check_version cuke test would pass :+1: