### PR TITLE
hoot:status may be undefined

### DIFF
--- a/js/hoot/model/Conflicts.js
+++ b/js/hoot/model/Conflicts.js
@@ -698,7 +698,7 @@ Hoot.model.conflicts = function(context)
 
         // If sourceLayer is still undefined, see if it is a layer that is no longer loaded
         if(!sourceLayer){
-            return mergeLayer.unloaded[this.decodeHootStatus(feature.tags['hoot:status']) - 1];
+            if (feature.tags['hoot:status']) return mergeLayer.unloaded[this.decodeHootStatus(feature.tags['hoot:status']) - 1];
         }
 
         return (sourceLayer) ? sourceLayer.mapId : null;


### PR DESCRIPTION
this may be the true cause of
https://github.com/ngageoint/hootenanny/issues/1602

the intermittent failure probably depends on what review is loaded first