### PR TITLE
bug fix: oauth: handle authentication failure gracefully

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -23,7 +23,7 @@ div.hoot-login-cell.text {
 }
 div.hoot-login-container {
     margin: 0px 15% 0px 15%;
-    padding: 10px;
+    padding: 10px 10px 60px 10px;
     width: 70%;
 }
 div.hoot-login-container p+h2 {

--- a/dist/index.html
+++ b/dist/index.html
@@ -49,13 +49,23 @@
                 d3.json('/hoot-services/auth/oauth1/verify?oauth_verifier=' + oauth_verifier + '&oauth_token=' + oauth_token, function(e, r) {
                     if(e) {
                         console.warn('failed to verify oauth tokens w/ provider:');
-                        console.warn('XMLHttpRequest.status', e.status);
-                        console.warn('XMLHttpRequest.responseText ', e.responseText);
-                        window.location.reload(true);
+                        console.warn('XMLHttpRequest.status', e.status || null);
+                        console.warn('XMLHttpRequest.responseText ', e.responseText) || null;
+
+                        if(opener) {
+                            window.onbeforeunload = function() {
+                                opener.oAuthDone(e, null);
+                            }
+                            window.close();
+                        } else {
+                            window.alert('Failed to complete oauth handshake. Check console for details & retry.');
+                            // clear oauth params.
+                            window.history.pushState({}, document.title, window.location.pathname);
+                        }
                     } else {
                         if(opener) {
                             window.onbeforeunload = function() {
-                                opener.oAuthDone(r);
+                                opener.oAuthDone(null, r);
                             }
                             window.close();
                         } else {
@@ -89,11 +99,20 @@
                 function launch_login(oauth_redirect_url) {
                     window.open(oauth_redirect_url, "hootenanny_login_redirect", "width=500,height=800,toolbar=no,status=no,menubar=no");
 
-                    window.oAuthDone = function(user_object) {
-                        if(localStorage) {
-                            localStorage.setItem('user', JSON.stringify(user_object));
+                    window.oAuthDone = function(e, user_object) {
+                        if(e) {
+                            console.warn('failed to verify oauth tokens w/ provider:');
+                            console.warn('XMLHttpRequest.status', e.status || null);
+                            console.warn('XMLHttpRequest.responseText ', e.responseText || null);
+
+                            window.alert('Failed to complete oauth handshake. Check console for details & retry.');
+                            window.history.pushState({}, document.title, window.location.pathname);
+                        } else {
+                            if(localStorage) {
+                                localStorage.setItem('user', JSON.stringify(user_object));
+                            }
+                            load();
                         }
-                        load();
                     }
                 }
                 Hoot.model.REST('servicesVersionInfo', function(services_version_info) {
@@ -101,7 +120,10 @@
                         // redirect.
                         Hoot.model.REST('getOAuthRedirectURL', function(oauth_redirect_url) {
                             if(oauth_redirect_url && oauth_redirect_url.error) {
-                                // TODO:
+                                // failed to get oauth redirect url from hoot-services.
+                                // must be offline or misconfigured.
+                                console.error(oauth_redirect_url);
+                                window.alert('Failed to retrieve authentication environment from services. Check console for details.');
                             } else {
                                 // render landing page.
                                 Hoot.view.login(function() {

--- a/index.html
+++ b/index.html
@@ -391,13 +391,24 @@
                 d3.json('/hoot-services/auth/oauth1/verify?oauth_verifier=' + oauth_verifier + '&oauth_token=' + oauth_token, function(e, r) {
                     if(e) {
                         console.warn('failed to verify oauth tokens w/ provider:');
-                        console.warn('XMLHttpRequest.status', e.status);
-                        console.warn('XMLHttpRequest.responseText ', e.responseText);
-                        window.location.reload(true);
+                        console.warn('XMLHttpRequest.status', e.status || null);
+                        console.warn('XMLHttpRequest.responseText ', e.responseText || null);
+
+                        if(opener) {
+                            window.onbeforeunload = function() {
+                                opener.oAuthDone(e, null);
+                            }
+                            window.close();
+                        } else {
+                            window.alert('Failed to complete oauth handshake. Check console for details & retry.');
+                            // clear oauth params.
+                            window.history.pushState({}, document.title, window.location.pathname);
+                        }
+
                     } else {
                         if(opener) {
                             window.onbeforeunload = function() {
-                                opener.oAuthDone(r);
+                                opener.oAuthDone(null, r);
                             }
                             window.close();
                         } else {
@@ -432,11 +443,21 @@
                     function launch_login(oauth_redirect_url) {
                         window.open(oauth_redirect_url, "hootenanny_login_redirect", "width=500,height=800,toolbar=no,status=no,menubar=no");
 
-                        window.oAuthDone = function(user_object) {
-                            if(localStorage) {
-                                localStorage.setItem('user', JSON.stringify(user_object));
+                        window.oAuthDone = function(e, user_object) {
+                            if(e) {
+                                console.warn('failed to verify oauth tokens w/ provider:');
+                                console.warn('XMLHttpRequest.status', e.status || null);
+                                console.warn('XMLHttpRequest.responseText ', e.responseText || null);
+
+                                window.alert('Failed to complete oauth handshake. Check console for details & retry.');
+                                window.history.pushState({}, document.title, window.location.pathname);
+
+                            } else {
+                                if(localStorage) {
+                                    localStorage.setItem('user', JSON.stringify(user_object));
+                                }
+                                load();
                             }
-                            load();
                         }
                     }
                     Hoot.model.REST('servicesVersionInfo', function(services_version_info) {
@@ -444,7 +465,11 @@
                             // redirect.
                             Hoot.model.REST('getOAuthRedirectURL', function(oauth_redirect_url) {
                                 if(oauth_redirect_url && oauth_redirect_url.error) {
-                                    // TODO:
+                                    // failed to get oauth redirect url from hoot-services.
+                                    // must be offline or misconfigured.
+                                    console.error(oauth_redirect_url);
+                                    window.alert('Failed to retrieve authentication environment from services. Check console for details.');
+
                                 } else {
                                     // render landing page.
                                     Hoot.view.login(function() {


### PR DESCRIPTION
refs #1237

* add padding to bottom of login page
* pass back errors from popup window console to main window console for easier debugging
* fix issue w/ infinite refresh loop
* remove oauth params from address bar when they fail