### PR TITLE
Install hoot from RPM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,8 +40,10 @@ pipeline {
                 expression { return params.UI }
             }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; aclocal && autoconf && autoheader && automake --add-missing --copy && ./configure --quiet --with-uitests'"
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; make ui2x-build; time -p make -s ui2x-test'"
+                // Build ui-2x
+                sh "vagrant ssh ${params.Box} -c 'cd hoot/hoot-ui-2x; npm i -s; npm run production -s'"
+                // Run ui-2x tests
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/database/AddKarmaTestUser.sh; cd hoot-ui-2x; npm test'"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,12 @@ pipeline {
         stage("Vagrant Up") {
             steps {
                 // TODO: Vagrant up --noprovision, install hoot from daily develop RPMs
-                sh "vagrant up ${params.Box} --provider aws"
+                sh "vagrant up ${params.Box} --provider aws --provision-with hoot"
+                sh "vagrant ssh ${params.Box} -c 'sudo yum install -y epel-release yum-utils'"
+                sh "vagrant ssh ${params.Box} -c 'sudo yum-config-manager --add-repo https://s3.amazonaws.com/hoot-repo/el7/pgdg95.repo'"
+                sh "vagrant ssh ${params.Box} -c 'sudo yum-config-manager --add-repo https://s3.amazonaws.com/hoot-repo/el7/develop/hoot.repo'"
+                sh "vagrant ssh ${params.Box} -c 'sudo yum makecache -y'"
+                sh "vagrant ssh ${params.Box} -c 'sudo yum install -y hootenanny-autostart'"
             }       
         }
         stage("UI") {
@@ -35,7 +40,7 @@ pipeline {
                 expression { return params.UI }
             }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; time -p make -s ui2x-test'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; make ui2x-build; time -p make -s ui2x-test'"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
                 expression { return params.UI }
             }
             steps {
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; aclocal && autoconf && autoheader && automake --add-missing --copy && ./configure --quiet --with-uitests'"
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; make ui2x-build; time -p make -s ui2x-test'"
             }
         }


### PR DESCRIPTION
Instead of compiling hootenanny to test the UI, we could install the latest RPM in the develop repository.  Once installed run UI tests against hoot install.  In theory, this should save time and cut down on unnecessary compiling.