### PR TITLE
layer review ui removed when layer deleted

### DIFF
--- a/modules/Hoot/managers/layerManager.js
+++ b/modules/Hoot/managers/layerManager.js
@@ -316,6 +316,7 @@ export default class Layers {
 
             this.hoot.context.flush();
         }
+        this.hoot.events.emit( 'loaded-layer-removed' );
     }
 
     removeAllLoadedLayers() {

--- a/modules/Hoot/ui/conflicts/conflicts.js
+++ b/modules/Hoot/ui/conflicts/conflicts.js
@@ -22,6 +22,22 @@ import {
     tooltipHtml
 } from '../../tools/utilities';
 
+
+const privateMethods = {
+    initData() {
+        return {
+            layer: null,
+            mapId: null,
+            reviewStats: null,
+            currentReviewItem: null,
+            currentRelation: null,
+            currentFeatures: null,
+            mergedItems: [],
+            mergedConflicts: []
+        };
+    }
+}
+
 /**
  * @class Conflicts
  */
@@ -33,16 +49,7 @@ export default class Conflicts {
         this.contentContainer = contentContainer;
 
         // data store for all conflicts components
-        this.data = {
-            layer: null,
-            mapId: null,
-            reviewStats: null,
-            currentReviewItem: null,
-            currentRelation: null,
-            currentFeatures: null,
-            mergedItems: [],
-            mergedConflicts: []
-        };
+        this.data = privateMethods.initData();
 
         this.buttonEnabled = true;
     }
@@ -54,6 +61,7 @@ export default class Conflicts {
         Hoot.context.map().on( 'drawn', null );
         this.map.unsetHighlight();
         this.container.remove();
+        this.data = privateMethods.initData();
     }
 
     /**

--- a/modules/Hoot/ui/conflicts/conflicts.js
+++ b/modules/Hoot/ui/conflicts/conflicts.js
@@ -36,7 +36,7 @@ const privateMethods = {
             mergedConflicts: []
         };
     }
-}
+};
 
 /**
  * @class Conflicts

--- a/modules/Hoot/ui/conflicts/traverse.js
+++ b/modules/Hoot/ui/conflicts/traverse.js
@@ -27,7 +27,7 @@ export default class Traverse {
     async jumpTo( direction ) {
         let hasChanges = Hoot.context.history().hasChanges(),
             reviewData = {},
-            reviewItem = null;
+            reviewItem;
 
         if ( hasChanges ) {
             let message = 'Please resolve or undo the current feature changes before proceeding to the next review.',

--- a/modules/Hoot/ui/conflicts/traverse.js
+++ b/modules/Hoot/ui/conflicts/traverse.js
@@ -27,7 +27,7 @@ export default class Traverse {
     async jumpTo( direction ) {
         let hasChanges = Hoot.context.history().hasChanges(),
             reviewData = {},
-            reviewItem;
+            reviewItem = null;
 
         if ( hasChanges ) {
             let message = 'Please resolve or undo the current feature changes before proceeding to the next review.',

--- a/modules/Hoot/ui/sidebar/layerReview.js
+++ b/modules/Hoot/ui/sidebar/layerReview.js
@@ -60,6 +60,9 @@ export default class LayerReview extends SidebarForm {
         this.reviewInfo.text( text );
     }
 
+    removeReviewUI() {
+        Hoot.ui.conflicts.deactivate();
+    }
     /**
      * Update text to reflect that all reviews have been resolved.
      * Display buttons to export data or to add another datasets
@@ -86,5 +89,6 @@ export default class LayerReview extends SidebarForm {
     listen() {
         Hoot.events.on( 'meta-updated', text => this.updateReviewCount( text ) );
         Hoot.events.on( 'review-complete', () => this.reviewComplete() );
+        Hoot.events.on( 'loaded-layer-removed', () => this.removeReviewUI() );
     }
 }


### PR DESCRIPTION
ref #1312

@brianhatchl I set reviewItem to null in traverse.js, it seems to have resolved the issue with finding the layer ids.

