### PR TITLE
Fix import and most other combobox's sort logic

### DIFF
--- a/modules/Hoot/tools/formFactory.js
+++ b/modules/Hoot/tools/formFactory.js
@@ -209,7 +209,11 @@ export default class FormFactory {
                     textB = b.value.toLowerCase();
 
                 return textA < textB ? -1 : textA > textB ? 1 : 0;
-            } ).unshift( { value: 'root', title: 0 } );
+            } )
+            
+            if (data.class === 'path-name') {
+                comboData = [ { value: 'root', title: 0 } ].concat(comboData);
+            }
         }
 
         field

--- a/modules/Hoot/tools/formFactory.js
+++ b/modules/Hoot/tools/formFactory.js
@@ -209,9 +209,9 @@ export default class FormFactory {
                     textB = b.value.toLowerCase();
 
                 return textA < textB ? -1 : textA > textB ? 1 : 0;
-            } )
+            } );
             
-            if (data.class === 'path-name') {
+            if ( data.class === 'path-name' ) {
                 comboData = [ { value: 'root', title: 0 } ].concat(comboData);
             }
         }


### PR DESCRIPTION
most likely I should self git blame here, but the "sorting items" logic in the combobox factory was wrong :disappointed: 

This fixes that issue and its downstream 'I can't select other folders' issue @kweint found
Also should fix all cases of selecting folder since those comboboxes share the `path-name` class I'm using here

closes #1371