### PR TITLE
get initial review extent from review item

### DIFF
--- a/modules/Hoot/managers/layerManager.js
+++ b/modules/Hoot/managers/layerManager.js
@@ -226,9 +226,9 @@ export default class Layers {
             this.loadedLayers[ layer.id ] = layer;
 
             if (layerExtent.toParam() !== '-180,-90,180,90') {
-                if (layer.merged && Hoot.context.map().trimmedExtentZoom(layerExtent) < 16) {
-                    _debounce(() => { Hoot.context.map().centerZoom(layerExtent.center(), 16); }, 400)();
-                } else {
+                if (Object.keys(this.loadedLayers).length === 1 //only zoom to the first layer loaded
+                        && !layer.merged //and only if not going into review mode
+                    ) {
                     this.hoot.context.extent(layerExtent);
                 }
             }
@@ -283,6 +283,21 @@ export default class Layers {
             if ( Hoot.ui.managePanel.isOpen ) {
                 Hoot.ui.navbar.toggleManagePanel();
             }
+
+            //Get an initial review item
+            //and zoom to it's bounds
+            let mapId = mergedLayer.id;
+            let sequence = -999;
+            let direction = 'forward';
+            let reviewItem = await Hoot.api.getNextReview( {mapId, sequence, direction} );
+            let reviewBounds = reviewItem.bounds.split(',').map(parseFloat);
+            let min = [ reviewBounds[0], reviewBounds[1] ],
+                max = [ reviewBounds[2], reviewBounds[3] ];
+            let reviewExtent = new GeoExtent( min, max );
+            this.hoot.context.extent(reviewExtent);
+
+            mergedLayer.reviewItem = reviewItem;
+            mergedLayer.reviewStats = reviewStats;
 
             mergedLayer.merged = true;
             mergedLayer.color  = 'green';

--- a/modules/Hoot/ui/conflicts/conflicts.js
+++ b/modules/Hoot/ui/conflicts/conflicts.js
@@ -87,15 +87,11 @@ export default class Conflicts {
         this.merge     = modules[ 4 ];
         this.resolve   = modules[ 5 ];
 
-        let reviewStats = await Hoot.api.getReviewStatistics( this.data.mapId );
-
-        if ( reviewStats.totalCount === 0 ) return;
-
         this.render();
 
         Hoot.context.map().on( 'drawn', () => this.map.setHighlight() );
 
-        this.traverse.jumpTo( 'forward' );
+        this.traverse.showFirstReview( layer );
     }
 
     /**
@@ -121,7 +117,7 @@ export default class Conflicts {
             .classed( 'meta-dialog', true )
             .append( 'span' )
             .classed( '_icon info light', true )
-            .html( '<strong class="review-note">Initialzing...</strong>' );
+            .html( '<strong class="review-note">Initializing...</strong>' );
 
         this.tooltip = tooltip()
             .placement( 'top' )

--- a/modules/Hoot/ui/conflicts/graphSync.js
+++ b/modules/Hoot/ui/conflicts/graphSync.js
@@ -60,11 +60,10 @@ export default class GraphSync {
 
             if ( memberCount !== relation.members.length ) {
                 return this.loadMissingFeatures( relId )
-                    .then( () => this.validateMemberCount( relId ) );
-            } else if ( memberCount === 1 ) {
-                // TODO: get back to this
-            } else {
-                // TODO: show alert
+                    .then( () => this.validateMemberCount( relId ) )
+                    .catch( err => {
+                        window.console.error(err);
+                    } );
             }
 
             return relation.members;
@@ -76,7 +75,7 @@ export default class GraphSync {
             return this.loadMissingFeatures( relId )
                 .then( () => this.validateMemberCount( relId ) )
                 .catch( err => {
-                    // TODO: show alert
+                    window.console.error(err);
                 } );
         }
     }

--- a/modules/Hoot/ui/conflicts/traverse.js
+++ b/modules/Hoot/ui/conflicts/traverse.js
@@ -19,6 +19,21 @@ export default class Traverse {
     }
 
     /**
+     * Loads initial review item when merged layer goes into review mode
+     *
+     * @param the review item
+     * @returns {Promise<void>}
+     */
+    async showFirstReview( layer ) {
+        this.data.reviewStats = layer.reviewStats;
+        this.data.currentReviewItem = layer.reviewItem;
+
+        //should already have review relation loaded by zoom
+        this.instance.graphSync.getRelationMembers( layer.reviewItem.relationId )
+            .then( members => this.instance.map.highlightLayer( members[ 0 ], members[ 1 ], true ) );
+    }
+
+    /**
      * Jumps to next available reviewable relation
      *
      * @param direction - forward | backward


### PR DESCRIPTION
refs #1506

The crux of the issue addressed is the map needs to be
zoomed to an editable extent before the UI can go into
review mode.  So get an initial review item (which now
supplies it's extent) and zoom the map.  Then instead of
loading a new review item we have a new method to
show the initial review item zoomed to.