### PR TITLE
Allow custom data extent to be used in bbox operations (clipping, grail, etc)

### DIFF
--- a/css/hoot/components/_clip.scss
+++ b/css/hoot/components/_clip.scss
@@ -41,18 +41,24 @@
 
     button {
         width: 100%;
+        border-radius: 0;
+        border: 1px solid $light3;
 
         &:first-child {
             border-radius: 4px 0 0 4px;
         }
 
         &:last-child {
-            border-right: 1px solid $light3 !important;
             border-radius: 0 4px 4px 0;
+        }
+
+        &:not(:last-child) {
+            border-right: 0px;
         }
 
         &.selected {
             background-color: $blue;
+            border-color: $blue1;
             color: $light;
         }
     }

--- a/modules/Hoot/tools/selectBbox.js
+++ b/modules/Hoot/tools/selectBbox.js
@@ -149,6 +149,24 @@ export default class SelectBbox extends EventEmitter {
                 that.handleBbox( that.context.map().extent() );
                 that.bboxSelectType = 'visualExtent';
             } );
+
+        let customDataLayer = this.context.layers().layer('data');
+        if (customDataLayer.hasData() && customDataLayer.enabled()) {
+            bboxOptions
+                .append( 'button' )
+                .classed( 'keyline-all', true )
+                .text( 'Use Custom Data Extent' )
+                .on( 'click', function() {
+                    d3.select( this.parentNode )
+                        .selectAll( 'button' )
+                        .classed( 'selected', false );
+
+                    d3.select( this ).classed( 'selected', true );
+
+                    that.handleBbox( customDataLayer.extent() );
+                    that.bboxSelectType = 'customDataExtent';
+                } );
+        }
     }
 
     handleBbox( extent ) {

--- a/modules/Hoot/tools/selectBbox.js
+++ b/modules/Hoot/tools/selectBbox.js
@@ -121,7 +121,6 @@ export default class SelectBbox extends EventEmitter {
 
         bboxOptions
             .append( 'button' )
-            .classed( 'keyline-all', true )
             .text( 'Draw Bounding Box' )
             .on( 'click', function() {
                 d3.select( this.parentNode )
@@ -137,8 +136,8 @@ export default class SelectBbox extends EventEmitter {
 
         bboxOptions
             .append( 'button' )
-            .classed( 'keyline-all selected', true )
-            .text( 'Use Visual Extent' )
+            .classed( 'selected', true )
+            .text( 'Visual Extent' )
             .on( 'click', function() {
                 d3.select( this.parentNode )
                     .selectAll( 'button' )
@@ -154,8 +153,7 @@ export default class SelectBbox extends EventEmitter {
         if (customDataLayer.hasData() && customDataLayer.enabled()) {
             bboxOptions
                 .append( 'button' )
-                .classed( 'keyline-all', true )
-                .text( 'Use Custom Data Extent' )
+                .text( 'Custom Data Extent' )
                 .on( 'click', function() {
                     d3.select( this.parentNode )
                         .selectAll( 'button' )

--- a/modules/svg/data.js
+++ b/modules/svg/data.js
@@ -532,7 +532,7 @@ export function svgData(projection, context, dispatch) {
 
     drawData.extent = function() {
         return geoExtent(d3_geoBounds({ type: 'LineString', coordinates: flattenCoords() }));
-    }
+    };
 
     drawData.fitZoom = function() {
         let coords = flattenCoords();


### PR DESCRIPTION
specifically, task bounds provided in a gpx file via querystring parameter.

To test, unzip this file 
[example.gpx.zip](https://github.com/ngageoint/hootenanny-ui/files/3437444/example.gpx.zip)
 in your `dist/` folder and open this url:

http://localhost:8080/#background=Bing&disable_features=boundaries&gpx=example.gpx&map=13.07/18.5246/-72.4554