### PR TITLE
Fixed #1553. set Hoot.layers.allLayers to empty array instead of object

### DIFF
--- a/modules/Hoot/managers/api.js
+++ b/modules/Hoot/managers/api.js
@@ -310,7 +310,7 @@ export default class API {
             .then( resp => {
                 let layers = resp.data.layers;
 
-                if ( !layers || !layers.length ){
+                if ( !layers ){
                     return resp.data;
                 } else {
                     return layers;


### PR DESCRIPTION
ref #1553 