### PR TITLE
extend hide/show conflation-type options to include differential conf…

### DIFF
--- a/css/hoot/components/_advancedOptions.scss
+++ b/css/hoot/components/_advancedOptions.scss
@@ -49,19 +49,15 @@
     white-space: nowrap;
     transition: width 250ms ease-in-out, box-shadow 250ms ease-in, visibility 300ms;
 
-    & > div {
-        position: absolute;
-        width: 350px;
-    }
-
     &.visible {
         width: 350px;
         visibility: visible;
         transition: width 250ms ease-in-out;
     }
 
+
     .advanced-opts-header {
-        height: 60px;
+        height: 5%;
         padding: 15px;
         box-shadow: 0 1px 10px 0 $light2;
 
@@ -80,9 +76,9 @@
     }
 
     .advanced-opts-content {
-        top: 60px;
+        height: 95%;
         overflow-x: hidden;
-        overflow-y: auto;
+        overflow-y: scroll;
     }
 
     .advanced-opts-actions {
@@ -127,7 +123,7 @@
             .adv-opts-inner-wrap-left {
                 width: 20px;
                 align-items: center;
-                input { 
+                input {
                     margin-top: 5px;
                 }
             }
@@ -137,9 +133,7 @@
     .group-body {
         display: flex;
         flex-direction: column;
-        overflow: auto;
         align-items: center;
-        max-height: 500px;
         padding: 15px 10px;
     }
 
@@ -167,13 +161,13 @@
 
         input.combobox-input {
             display: inline-block;
-        }    
+        }
     }
 
     .hoot-form-field-checkbox {
         flex-direction: row;
         align-items: center;
-        
+
         .hoot-field-title-checkbox-wrap {
             display: flex;
             height: inherit;
@@ -183,8 +177,8 @@
             }
         }
         .hoot-field-input-checkbox-wrap {
-            width: 15%; 
-            height: inherit;    
+            width: 15%;
+            height: inherit;
             display: flex;
             justify-content: center;
             input {
@@ -246,6 +240,7 @@
 
 @media only screen and (max-width: 1160px) {
     #advanced-opts-panel {
+
         & > div {
             position: absolute;
             width: 300px;

--- a/modules/Hoot/config/domMetadata.js
+++ b/modules/Hoot/config/domMetadata.js
@@ -75,17 +75,19 @@ export function layerConflateForm( data ) {
                     advancedOpts.createGroups(advOpts);
                 } else {
                     // disable & enable the attribute conflation group.
-                    let attributeGroup = d3.select( '.advanced-opts-content #Attribute_group' ),
-                        isAttribute = d3.select( '#conflateType' ).property( 'value' ) === 'Attribute';
+                    [ 'Attribute', 'Differential' ].forEach((conflationGroup) => {
+                        let confGroup = d3.select( `.advanced-opts-content #${conflationGroup}_group` ),
+                            isGroup = d3.select( '#conflateType' ).property( 'value' ) === conflationGroup;
 
-                    attributeGroup.select( '.adv-opt-title' )
-                        .classed( 'adv-opt-title-disabled', !isAttribute );
+                        confGroup.select( '.adv-opt-title' )
+                            .classed( 'adv-opt-title-disabled', !isGroup );
 
-                    attributeGroup.select( '.adv-opt-toggle' )
-                        .classed( 'toggle-disabled', !isAttribute );
+                        confGroup.select( '.adv-opt-toggle' )
+                            .classed( 'toggle-disabled', !isGroup );
 
-                    attributeGroup
-                        .select( '.group-body', true );
+                        confGroup
+                            .select( '.group-body', true );
+                    })
                 }
             }
         },

--- a/modules/Hoot/config/domMetadata.js
+++ b/modules/Hoot/config/domMetadata.js
@@ -87,7 +87,7 @@ export function layerConflateForm( data ) {
 
                         confGroup
                             .select( '.group-body', true );
-                    })
+                    });
                 }
             }
         },

--- a/modules/Hoot/config/domMetadata.js
+++ b/modules/Hoot/config/domMetadata.js
@@ -77,7 +77,7 @@ export function layerConflateForm( data ) {
                     // disable & enable the attribute conflation group.
                     [ 'Attribute', 'Differential' ].forEach((conflationGroup) => {
                         let confGroup = d3.select( `.advanced-opts-content #${conflationGroup}_group` ),
-                            isGroup = d3.select( '#conflateType' ).property( 'value' ) === conflationGroup;
+                            isGroup = d3.select( '#conflateType' ).property( 'value' ).includes(conflationGroup);
 
                         confGroup.select( '.adv-opt-title' )
                             .classed( 'adv-opt-title-disabled', !isGroup );

--- a/modules/Hoot/managers/api.js
+++ b/modules/Hoot/managers/api.js
@@ -1260,9 +1260,7 @@ export default class API {
         const params = {
             url: `${ this.translationUrl }schema`,
             method: 'GET',
-            params: {
-                ...data
-            }
+            params: data
         };
 
         return this.request( params )
@@ -1310,9 +1308,7 @@ export default class API {
         const params = {
             url: `${ this.translationUrl }translateTo`,
             method: 'GET',
-            params: {
-                ...p
-            }
+            params: p
         };
 
         return this.request( params )

--- a/modules/Hoot/ui/sidebar/advancedOpts.js
+++ b/modules/Hoot/ui/sidebar/advancedOpts.js
@@ -127,7 +127,7 @@ export default class AdvancedOpts {
             .classed( 'adv-opt-title-disabled', !shouldHide );
 
         if (fromLabel) {
-            input.property('checked', shouldHide)
+            input.property('checked', shouldHide);
         }
 
         if (shouldHide) {
@@ -453,7 +453,7 @@ export default class AdvancedOpts {
             groupToggle = groupToggle
                 .merge(groupToggleEnter)
                 .on('click', () => instance.showBody(d));
-                
+
             let toggleWrap = groupToggle.selectAll( '.inner-wrapper' )
                 .data( [ d ] );
 

--- a/modules/Hoot/ui/sidebar/advancedOpts.js
+++ b/modules/Hoot/ui/sidebar/advancedOpts.js
@@ -110,14 +110,8 @@ export default class AdvancedOpts {
     toggleOption(d, shouldHide = false, fromLabel = false) {
         let label = d3.select( `#${d.name}_label` ),
             parent = d3.select( `#${d.name}_group` ),
-            input = d3.select( `#${d.name}-toggle` );
-
-        // do not toggle if the accordion is open
-        if (!d3.select( `#${ d.name }_group .group-body` ).classed( 'hidden' )) {
-            input.property( 'checked', true );
-            return;
-        }
-
+            input = d3.select( `#${d.name}-toggle` ),
+            body = d3.select( `#${ d.name }_group .group-body`);
 
         parent
             .select( '.group-toggle-caret-wrap' )
@@ -133,6 +127,10 @@ export default class AdvancedOpts {
         if (shouldHide) {
             parent.select( '.group-body' )
                 .classed( 'hidden', true );
+        }
+
+        if (!body.classed( 'hidden' )) {
+            body.classed('hidden', true);
         }
 
     }
@@ -203,11 +201,19 @@ export default class AdvancedOpts {
             .append( 'span' )
             .classed( 'adv-opt-title', true );
 
-        innerLabel.merge(innerLabelEnter)
+        innerLabel = innerLabel.merge(innerLabelEnter)
             .attr( 'id', d => `${ d.name }_label` )
             .classed( 'adv-opt-title-disabled', false )
             .classed( 'adv-opts-group-title', true)
             .text( d => d.members.length ? `${d.label} Options` : d.label);
+
+        innerLabel.on('click', () => {
+            let input = d3.select( `#${d.name}-toggle` ),
+                shouldHide = !input.empty() && !input.property('checked');
+
+            instance.toggleOption(d, shouldHide, true);
+        })
+
     }
 
     caretWrap(toggleInput) {
@@ -230,15 +236,11 @@ export default class AdvancedOpts {
     }
 
     showBody(d) {
-
-        if (d3.event.target.classList.contains( 'conflate-type-toggle' )) return;
-
-
-        if (d3.event.target.classList.contains( 'adv-opts-group-title' )) {
-            let input = d3.select( `#${d.name}-toggle` ),
-                shouldHide = !input.empty() && !input.property('checked');
-            instance.toggleOption(d, shouldHide, true);
-        } else if (d.members.length) {
+        if (d3.event.target.classList.contains( 'conflate-type-toggle' ) ||
+            d3.event.target.classList.contains( 'adv-opts-group-title' )) {
+            return;
+        }
+        if (d.members.length) {
             let bodyState = d3.select( `#${ d.name }_group .group-body` ).classed( 'hidden' );
             d3.selectAll('.advanced-opts-content .form-group .group-body')
                 .classed('hidden', function(data) {

--- a/modules/Hoot/ui/sidebar/advancedOpts.js
+++ b/modules/Hoot/ui/sidebar/advancedOpts.js
@@ -114,7 +114,6 @@ export default class AdvancedOpts {
         parent
             .select( '.group-toggle-caret-wrap' )
             .classed( 'toggle-disabled', shouldHide );
-
         label
             .classed( 'adv-opt-title-disabled', !label.classed( 'adv-opt-title-disabled' ) );
 
@@ -145,7 +144,6 @@ export default class AdvancedOpts {
         let innerWrapLeftEnter = innerWrapLeft.enter()
             .append( 'div' )
             .classed( 'adv-opts-inner-wrap-left', true );
-
 
         innerWrapLeft = innerWrapLeft.merge(innerWrapLeftEnter);
 
@@ -180,16 +178,6 @@ export default class AdvancedOpts {
 
         innerLabelWrap = innerLabelWrap.merge(innerLabelWrapEnter);
 
-        innerLabelWrap
-            .on('click', d => {
-                let toggle = d3.select( `#${d.name}-toggle`),
-                    checked = toggle.property( 'checked' );
-
-                toggle.property( 'checked', !checked );
-
-                toggleOption( d, checked );
-            } );
-
         let innerLabel = innerLabelWrap.selectAll( '.adv-opt-title' )
             .data([ d ]);
 
@@ -197,7 +185,7 @@ export default class AdvancedOpts {
 
         let innerLabelEnter = innerLabel.enter()
             .append( 'span' )
-            .classed( 'adv-opt-title', true );
+            .classed( 'adv-opt-title', true )
 
         innerLabel.merge(innerLabelEnter)
             .attr( 'id', d => `${ d.name }_label` )
@@ -218,18 +206,28 @@ export default class AdvancedOpts {
             .classed( 'group-toggle-caret-wrap', true)
             .append( 'div' )
             .attr( 'class', 'adv-opt-toggle' )
-            .classed( 'combobox-caret', d => d.members.length )
-            .on( 'click', function(d) {
-                if (d.members.length) {
-                    let body      = d3.select( `#${ d.name }_group` ).select( '.group-body' ),
-                        bodyState = body.classed( 'hidden' );
-
-                    body.classed( 'hidden', !bodyState );
-                    body.classed( 'keyline-bottom', bodyState );
-                }
-            });
+            .classed( 'combobox-caret', d => d.members.length );
 
         caretWrap.merge(caretWrapEnter);
+        caretWrap.on( 'click', instance.showBody);
+    }
+
+    showBody(d) {
+        if (d3.event.target && d3.event.target.classList.contains('conflate-type-toggle')) return;
+        if (d.members.length) {
+            let body      = d3.select( `#${ d.name }_group` ).select( '.group-body' ),
+                bodyState = body.classed( 'hidden' );
+
+            // body.classed( 'hidden', !bodyState );
+            // body.classed( 'keyline-bottom', bodyState );
+            d3.selectAll('.advanced-opts-content .form-group .group-body')
+                .classed('hidden', function(data) {
+                    return data.name === d.name ? !bodyState : true;
+                })
+                .classed('keyline-bottom', function(data) {
+                    return data.name === d.name ? bodyState : false;
+                });
+        }
     }
 
     fieldLabel(fieldContainer) {
@@ -351,7 +349,7 @@ export default class AdvancedOpts {
                         d.send = value !== d.default;
                         if ([ 'double', 'int', 'long' ].indexOf ( d.type ) !== -1 ) {
                             d3.select( `#${d.id}-label-wrao` )
-                                .call(self.notNumber, value);
+                                .call(instance.notNumber, value);
                         }
                     });
             }
@@ -391,8 +389,7 @@ export default class AdvancedOpts {
     }
 
     createGroups(advOpts) {
-        let self = this,
-            group = this.contentDiv
+        let group = this.contentDiv
                 .selectAll( '.form-group' )
                 .data( advOpts );
 
@@ -419,6 +416,8 @@ export default class AdvancedOpts {
 
             groupToggle = groupToggle.merge(groupToggleEnter);
 
+            groupToggle.on('click', () => instance.showBody(d));
+
             let toggleWrap = groupToggle.selectAll( '.inner-wrapper' )
                 .data( [ d ] );
 
@@ -432,8 +431,8 @@ export default class AdvancedOpts {
             toggleWrap = toggleWrap.merge(toggleWrapEnter);
 
             toggleWrap
-                .call(self.innerWrap, self.toggleOption)
-                .call(self.caretWrap);
+                .call(instance.innerWrap, instance.toggleOption)
+                .call(instance.caretWrap);
 
             let defaultDisables = ['Attribute', 'Differential'];
             if ( defaultDisables.indexOf(d.name) !== -1 ) {
@@ -484,8 +483,8 @@ export default class AdvancedOpts {
                 let fieldContainer = d3.select( this );
 
                 fieldContainer
-                    .call(self.fieldLabel)
-                    .call(self.fieldInput, isCleaning );
+                    .call(instance.fieldLabel)
+                    .call(instance.fieldInput, isCleaning );
             });
 
         });

--- a/modules/Hoot/ui/sidebar/advancedOpts.js
+++ b/modules/Hoot/ui/sidebar/advancedOpts.js
@@ -149,7 +149,7 @@ export default class AdvancedOpts {
 
         innerWrapLeft = innerWrapLeft.merge(innerWrapLeftEnter);
 
-        if ( d.name !== 'Cleaning' && d.name !== 'General' && d.name !== 'Attribute' ) {
+        if ( !['Cleaning', 'General', 'Attribute', 'Differential'].includes(d.name) ) {
             let innerInput = innerWrapLeft.selectAll( '.conflate-type-toggle' )
                 .data( [ d ] );
 
@@ -435,13 +435,14 @@ export default class AdvancedOpts {
                 .call(self.innerWrap, self.toggleOption)
                 .call(self.caretWrap);
 
-            if ( d.name === 'Attribute' ) {
-                let isAttribute = d3.select( '#conflateType' ).property( 'value' ) === 'Attribute';
+            let defaultDisables = ['Attribute', 'Differential'];
+            if ( defaultDisables.indexOf(d.name) !== -1 ) {
+                let shouldDisable = d3.select( '#conflateType' ).property( 'value' ) === d.name;
                 group.select( '.adv-opt-title' )
-                    .classed( 'adv-opt-title-disabled', !isAttribute );
+                    .classed( 'adv-opt-title-disabled', !shouldDisable );
 
                 group.select( '.adv-opt-toggle' )
-                    .classed( 'toggle-disabled', !isAttribute );
+                    .classed( 'toggle-disabled', !shouldDisable );
             }
 
 

--- a/modules/Hoot/ui/sidebar/advancedOpts.js
+++ b/modules/Hoot/ui/sidebar/advancedOpts.js
@@ -208,8 +208,11 @@ export default class AdvancedOpts {
             .text( d => d.members.length ? `${d.label} Options` : d.label);
 
         innerLabel.on('click', () => {
-            let input = d3.select( `#${d.name}-toggle` ),
-                shouldHide = !input.empty() && !input.property('checked');
+            let input = d3.select( `#${d.name}-toggle` );
+
+            if (input.empty()) return;
+
+            let shouldHide = d3.select(this).classed('adv-opt-title-disabled')
 
             instance.toggleOption(d, shouldHide, true);
         })

--- a/modules/Hoot/ui/sidebar/advancedOpts.js
+++ b/modules/Hoot/ui/sidebar/advancedOpts.js
@@ -212,10 +212,9 @@ export default class AdvancedOpts {
 
             if (input.empty()) return;
 
-            let shouldHide = d3.select(this).classed('adv-opt-title-disabled')
-
+            let shouldHide = d3.select(this).classed('adv-opt-title-disabled');
             instance.toggleOption(d, shouldHide, true);
-        })
+        });
 
     }
 

--- a/modules/Hoot/ui/sidebar/advancedOpts.js
+++ b/modules/Hoot/ui/sidebar/advancedOpts.js
@@ -185,7 +185,7 @@ export default class AdvancedOpts {
 
         let innerLabelEnter = innerLabel.enter()
             .append( 'span' )
-            .classed( 'adv-opt-title', true )
+            .classed( 'adv-opt-title', true );
 
         innerLabel.merge(innerLabelEnter)
             .attr( 'id', d => `${ d.name }_label` )


### PR DESCRIPTION
ref #1552

In the same way that we made attribute conflation enable/disable based on it being selected in the conflation form, we'll now do the same for differential