### PR TITLE
because osm is default export format, show include hoot tags by default

### DIFF
--- a/modules/Hoot/config/domMetadata.js
+++ b/modules/Hoot/config/domMetadata.js
@@ -371,7 +371,7 @@ export function exportDataForm( zipOutput ) {
             id: exportHootTags,
             inputType: 'checkbox',
             checked: false,
-            hidden: true
+            hidden: false
         },
         // {
         //     label: 'Tag Overrides',


### PR DESCRIPTION
we should show "Include hoot tags?" initially because OSM is the default export format.  Otherwise you have to select something else and then re-select OSM to get the option to appear.