### PR TITLE
Fixed #1704. job panel offset bug

### DIFF
--- a/modules/Hoot/ui/managePanel/jobs.js
+++ b/modules/Hoot/ui/managePanel/jobs.js
@@ -364,7 +364,10 @@ export default class Jobs extends Tab {
 
     populateJobsHistory( jobs ) {
         // if you're on a page that no longer has data, go to last page with data
-        if ( jobs.length === 0 && (this.paging.getCurrentPage() >= this.getPages()) ) {
+        if ( jobs.length === 0 && (this.paging.getCurrentPage() >= this.getPages())
+            // or your current page is greater than the number of pages
+            // like when you change the page size from the last page
+            || (this.paging.getCurrentPage() > this.getPages())) {
             this.paging.setPage( this.getPages() );
         }
 

--- a/modules/Hoot/ui/managePanel/jobs.js
+++ b/modules/Hoot/ui/managePanel/jobs.js
@@ -363,6 +363,11 @@ export default class Jobs extends Tab {
 
 
     populateJobsHistory( jobs ) {
+        // if you're on a page that no longer has data, go to last page with data
+        if ( jobs.length === 0 && (this.paging.getCurrentPage() >= this.getPages()) ) {
+            this.paging.setPage( this.getPages() );
+        }
+
         let that = this;
         let table = this.jobsHistoryTable
             .selectAll('table')

--- a/modules/Hoot/ui/managePanel/jobs/paging.js
+++ b/modules/Hoot/ui/managePanel/jobs/paging.js
@@ -20,6 +20,10 @@ export default class Paging {
         that.setPage(+that.pageElement.text() - 1);
     }
 
+    getCurrentPage() {
+        return this.pageElement.text();
+    }
+
     setPage(p) {
         if (p > 0 && p <= this.container.getPages()) {
             this.pageElement.text(p);


### PR DESCRIPTION
If the user is on a page with no data, it will go to the last page with data now

ref #1704 