### PR TITLE
handle a missing mapid in the url hash

### DIFF
--- a/modules/Hoot/managers/layerManager.js
+++ b/modules/Hoot/managers/layerManager.js
@@ -61,7 +61,22 @@ export default class Layers {
             //load hash layers if set
             if (!_isEmpty(this.hashLayers)) {
                 Object.keys(this.hashLayers).forEach(k => {
-                    this.addHashLayer(k, this.hashLayers[k]);
+                    //check that hash layer exists
+                    let mapId = this.hashLayers[k];
+                    if (this.findBy( 'id', mapId)) {
+                        this.addHashLayer(k, mapId);
+                    } else {
+
+                        Hoot.message.alert({
+                            message: `Could not find layer to load with map ID ${mapId}`,
+                            type: 'warn'
+                        });
+                        delete this.hashLayers[k];
+                        //update url hash
+                        var q = utilStringQs(window.location.hash.substring(1));
+                        delete q[(k === 'reference') ? 'primary' : k];
+                        window.location.replace('#' + utilQsString(q, true));
+                    }
                 });
 
                 this.hashLayers = {};


### PR DESCRIPTION
This fixes a silent failure (js error) when a mapid in the url hash for primary or secondary does not exist.
Now the UI will show a warning and remove the missing mapid from the url hash