### PR TITLE
handle an upload error from services as well as hoot command line

### DIFF
--- a/modules/Hoot/ui/modals/ImportMultiDatasets.js
+++ b/modules/Hoot/ui/modals/ImportMultiDatasets.js
@@ -419,13 +419,20 @@ export default class ImportMultiDatasets {
                             type = err.type,
                             keepOpen = true;
 
-                        if (err.data.commandDetail.length > 0 && err.data.commandDetail[0].stderr !== '') {
-                            message += err.data.commandDetail[0].stderr;
+                        if (typeof err.data === 'string') {
+                            message = err.data;
+                        }
+
+                        if (err.data instanceof Object && err.data.commandDetail && err.data.commandDetail.length > 0 && err.data.commandDetail[0].stderr !== '') {
+                            message = err.data.commandDetail[0].stderr;
                         }
 
                         Hoot.message.alert( { message, type, keepOpen } );
+                    })
+                    .finally( () => {
+                        this.container.remove();
+                        Hoot.events.emit( 'modal-closed' );
                     });
-
             });
         });
 

--- a/modules/Hoot/ui/modals/importDataset.js
+++ b/modules/Hoot/ui/modals/importDataset.js
@@ -469,8 +469,14 @@ export default class ImportDataset {
                 type = err.type,
                 keepOpen = true;
 
-                if ( err.data && err.data.commandDetail.length > 0 && err.data.commandDetail[0].stderr !== '') {
-                    message = err.data.commandDetail[0].stderr;
+                if ( err.data ) {
+                    if (typeof err.data === 'string') {
+                        message = err.data;
+                    }
+
+                    if (err.data instanceof Object && err.data.commandDetail && err.data.commandDetail.length > 0 && err.data.commandDetail[0].stderr !== '') {
+                        message = err.data.commandDetail[0].stderr;
+                    }
                 }
 
                 Hoot.message.alert( { message, type, keepOpen } );


### PR DESCRIPTION
fixes #1796

You can reproduce the bug by trying to upload a `*.osm.zip` file with multiple osm files in it.  You can test that hoot commandline errors still work after this fix by uploading a `*.osm` file with invalid osm xml inside.