### PR TITLE
fix js error when adv opt form not shown

### DIFF
--- a/modules/Hoot/ui/sidebar/advancedOpts.js
+++ b/modules/Hoot/ui/sidebar/advancedOpts.js
@@ -38,7 +38,7 @@ export default class AdvancedOpts {
     }
 
     get isOpen() {
-        return this.form.classed( 'visible' );
+        return this.form && this.form.classed( 'visible' );
     }
 
     async init() {


### PR DESCRIPTION
Found this error when trying to remove a single layer from the map
```
advancedOpts.js:41 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'classed')
    at get isOpen [as isOpen] (advancedOpts.js:41:1)
    at Layers.removeLoadedLayer (layerManager.js:492:1)
    at HTMLButtonElement.<anonymous> (sidebarController.js:175:1)
```