### PR TITLE
Export zip format now includes original format extension

### DIFF
--- a/js/hoot/model/Export.js
+++ b/js/hoot/model/Export.js
@@ -215,10 +215,10 @@ Hoot.model.export = function (context)
                 }
                 else {
                     var sUrl = '../hoot-services/job/export/' + result.jobId + '?' + outNameParam + '&removecache=true';
-                    if (selectedOutType === 'osm.pbf') {
-                        // specify the file ext since the default is zip and there is no need to zip a pbf file
-                        sUrl = sUrl + '&ext=pbf';
-                    }
+                    // if (selectedOutType === 'osm.pbf') {
+                    //     // specify the file ext since the default is zip and there is no need to zip a pbf file
+                    //     sUrl = sUrl + '&ext=pbf';
+                    // }
                     var link = document.createElement('a');
                     link.href = sUrl;
                     if (link.download !== undefined) {

--- a/js/hoot/model/Export.js
+++ b/js/hoot/model/Export.js
@@ -176,7 +176,7 @@ Hoot.model.export = function (context)
             clearInterval(statusTimer);
             var outNameParam = '';
             if (outputname !== null) {
-                outNameParam = 'outputname=' + outputname;
+                outNameParam = 'outputname=' + outputname + '.' + selectedOutType;
             }
             if (exportCallback) {
                 exportCallback(result.status);

--- a/js/hoot/model/Export.js
+++ b/js/hoot/model/Export.js
@@ -217,7 +217,7 @@ Hoot.model.export = function (context)
                     var sUrl = '../hoot-services/job/export/' + result.jobId + '?' + outNameParam + '&removecache=true';
                     if (selectedOutType === 'osm.pbf') {
                         // specify the file ext since the default is zip and there is no need to zip a pbf file
-                        sUrl = sUrl + '&ext=osm.pbf';
+                        sUrl = sUrl + '&ext=pbf';
                     }
                     var link = document.createElement('a');
                     link.href = sUrl;

--- a/test/spec/hoot/model/export.js
+++ b/test/spec/hoot/model/export.js
@@ -93,7 +93,7 @@ describe('iD.Hoot.Model.Export', function(){
             expect(oReq.inputtype).to.eql("db");
             expect(oReq.input).to.eql("test_input_name");
             expect(oReq.outputtype).to.eql("gdb");
-            expect(oReq.outputname).to.eql("out_name_123");
+            expect(oReq.outputname).to.eql("out_name_123.gdb");
             expect(requests[0].url).to.eql("../hoot-services/job/export/execute");
             done();
           });


### PR DESCRIPTION
So zipping a shapefile will be named `export.shp.zip`