### PR TITLE
Open in JOSM must use absolute url path

### DIFF
--- a/modules/Hoot/config/apiConfig.js
+++ b/modules/Hoot/config/apiConfig.js
@@ -10,9 +10,8 @@
 
 function relativePath() {
     let path = window.location.pathname;
-    let pathWithoutFile = '/' + path.split('/').filter(p => p.length).slice(0, -1).join('/');
-    let pathRelative = pathWithoutFile + 'hoot-services';
-
+    let pathWithoutFile = path.substr(0, path.lastIndexOf('/'));
+    let pathRelative = ( (pathWithoutFile === '') ? '' : '../' ) + 'hoot-services';
     return pathRelative;
 }
 

--- a/modules/Hoot/config/apiConfig.js
+++ b/modules/Hoot/config/apiConfig.js
@@ -10,8 +10,8 @@
 
 function relativePath() {
     let path = window.location.pathname;
-    let pathWithoutFile = path.substr(0, path.lastIndexOf('/'));
-    let pathRelative = ( (pathWithoutFile === '') ? '' : '../' ) + 'hoot-services';
+    let pathWithoutFile = '/' + path.split('/').filter(p => p.length).slice(0, -1).join('/');
+    let pathRelative = pathWithoutFile + 'hoot-services';
 
     return pathRelative;
 }

--- a/modules/Hoot/config/apiConfig.js
+++ b/modules/Hoot/config/apiConfig.js
@@ -11,7 +11,7 @@
 function relativePath() {
     let path = window.location.pathname;
     let pathWithoutFile = path.substr(0, path.lastIndexOf('/'));
-    let pathRelative = ( (pathWithoutFile === '') ? '' : '..' ) + '/hoot-services';
+    let pathRelative = ( (pathWithoutFile === '') ? '' : '../' ) + 'hoot-services';
 
     return pathRelative;
 }

--- a/modules/Hoot/managers/api.js
+++ b/modules/Hoot/managers/api.js
@@ -987,23 +987,8 @@ export default class API {
             path: '/osm/api/0.6/user/session',
             method: 'GET'
         };
-        function absolute(base, rel) {
-            var st = base.split("/");
-            var arr = rel.split("/");
-            st.pop(); // ignore the current file name (or no string)
-           // (ignore if "base" is the current folder without having slash in trail)
-            for (var i = 0; i < arr.length; i++) {
-                if (arr[i] == ".")
-                    continue;
-                if (arr[i] == "..")
-                    st.pop();
-                else
-                    st.push(arr[i]);
-            }
-            return st.join("/");
-        }
 
-        let absUrl = absolute(this.detect.host, `${this.baseUrl}/job/export/${id}?outputname=${name}.${ext}.zip`);
+        let absUrl = this.detect.absolute(this.detect.host, `${this.baseUrl}/job/export/${id}?outputname=${name}.${ext}.zip`);
         console.log(absUrl);
         // return this.request( params )
         //     .then( resp => {

--- a/modules/Hoot/managers/api.js
+++ b/modules/Hoot/managers/api.js
@@ -989,22 +989,21 @@ export default class API {
         };
 
         let absUrl = this.detect.absolute(this.detect.host, `${this.baseUrl}/job/export/${id}?outputname=${name}.${ext}.zip`);
-        console.log(absUrl);
-        // return this.request( params )
-        //     .then( resp => {
-        //         let rc = window.open('http://127.0.0.1:8111/import?'
-        //             + `headers=Cookie,SESSION=${resp.data}`
-        //             + '&new_layer=true'
-        //             + `&layer_name=${name}`
-        //             + `&url=${absUrl}`
-        //             , '_blank');
-        //         // Close the window after 1 second
-        //         setTimeout(() => {
-        //             if (rc && !rc.closed) {
-        //                 rc.close();
-        //             }
-        //         }, 1000);
-        // });
+        return this.request( params )
+            .then( resp => {
+                let rc = window.open('http://127.0.0.1:8111/import?'
+                    + `headers=Cookie,SESSION=${resp.data}`
+                    + '&new_layer=true'
+                    + `&layer_name=${name}`
+                    + `&url=${absUrl}`
+                    , '_blank');
+                // Close the window after 1 second
+                setTimeout(() => {
+                    if (rc && !rc.closed) {
+                        rc.close();
+                    }
+                }, 1000);
+        });
      }
 
     saveChangeset( id, name ) {

--- a/modules/Hoot/managers/api.js
+++ b/modules/Hoot/managers/api.js
@@ -987,21 +987,39 @@ export default class API {
             path: '/osm/api/0.6/user/session',
             method: 'GET'
         };
-        return this.request( params )
-            .then( resp => {
-                let rc = window.open('http://127.0.0.1:8111/import?'
-                    + `headers=Cookie,SESSION=${resp.data}`
-                    + '&new_layer=true'
-                    + `&layer_name=${name}`
-                    + `&url=${this.detect.host}${this.baseUrl}/job/export/${id}?outputname=${name}.${ext}.zip`
-                    , '_blank');
-                // Close the window after 1 second
-                setTimeout(() => {
-                    if (rc && !rc.closed) {
-                        rc.close();
-                    }
-                }, 1000);
-        });
+        function absolute(base, rel) {
+            var st = base.split("/");
+            var arr = rel.split("/");
+            st.pop(); // ignore the current file name (or no string)
+           // (ignore if "base" is the current folder without having slash in trail)
+            for (var i = 0; i < arr.length; i++) {
+                if (arr[i] == ".")
+                    continue;
+                if (arr[i] == "..")
+                    st.pop();
+                else
+                    st.push(arr[i]);
+            }
+            return st.join("/");
+        }
+
+        let absUrl = absolute(this.detect.host, `${this.baseUrl}/job/export/${id}?outputname=${name}.${ext}.zip`);
+        console.log(absUrl);
+        // return this.request( params )
+        //     .then( resp => {
+        //         let rc = window.open('http://127.0.0.1:8111/import?'
+        //             + `headers=Cookie,SESSION=${resp.data}`
+        //             + '&new_layer=true'
+        //             + `&layer_name=${name}`
+        //             + `&url=${absUrl}`
+        //             , '_blank');
+        //         // Close the window after 1 second
+        //         setTimeout(() => {
+        //             if (rc && !rc.closed) {
+        //                 rc.close();
+        //             }
+        //         }, 1000);
+        // });
      }
 
     saveChangeset( id, name ) {

--- a/modules/Hoot/managers/api.js
+++ b/modules/Hoot/managers/api.js
@@ -993,7 +993,7 @@ export default class API {
                     + `headers=Cookie,SESSION=${resp.data}`
                     + '&new_layer=true'
                     + `&layer_name=${name}`
-                    + `&url=${this.detect.origin}${this.baseUrl}/job/export/${id}?outputname=${name}.${ext}.zip`
+                    + `&url=${this.detect.host}${this.baseUrl}/job/export/${id}?outputname=${name}.${ext}.zip`
                     , '_blank');
                 // Close the window after 1 second
                 setTimeout(() => {

--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -107,8 +107,6 @@ export function utilDetect(force) {
         origin = loc.protocol + '//' + loc.hostname + (loc.port ? ':' + loc.port: '');
     }
 
-    detected.origin = origin;
-
     detected.host = origin + loc.pathname;
 
     detected.filedrop = (window.FileReader && 'ondrop' in window);

--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -115,6 +115,25 @@ export function utilDetect(force) {
 
     detected.cssfilters = !(detected.ie || detected.browser.toLowerCase() === 'edge');
 
+    // source https://www.geeksforgeeks.org/convert-relative-path-url-to-absolute-path-url-using-javascript/
+    function absolute(base, rel) {
+        var st = base.split('/');
+        var arr = rel.split('/');
+        st.pop(); // ignore the current file name (or no string)
+       // (ignore if 'base' is the current folder without having slash in trail)
+        for (var i = 0; i < arr.length; i++) {
+            if (arr[i] === '.')
+                continue;
+            if (arr[i] === '..')
+                st.pop();
+            else
+                st.push(arr[i]);
+        }
+        return st.join('/');
+    }
+
+    detected.absolute = absolute;
+
     function nav(x) {
         return navigator.userAgent.indexOf(x) !== -1;
     }

--- a/test/spec/util/detect.js
+++ b/test/spec/util/detect.js
@@ -1,0 +1,23 @@
+describe('iD.detect', function() {
+    var detect = iD.utilDetect();
+    describe('absolute', function() {
+        it('get the absolute url for dev webpack', function() {
+            var base = 'https://localhost:8080/';
+            var rel = 'hoot-services';
+            var abs = detect.absolute(base, rel);
+            expect(abs).to.eql('https://localhost:8080/hoot-services');
+        });
+        it('get the absolute url for dev tomcat', function() {
+            var base = 'https://localhost:8443/hootenanny-id/';
+            var rel = '../hoot-services';
+            var abs = detect.absolute(base, rel);
+            expect(abs).to.eql('https://localhost:8080/hoot-services');
+        });
+        it('get the absolute url for production', function() {
+            var base = 'https://localhost/hootenanny/hootenanny-id/';
+            var rel = '../hoot-services';
+            var abs = detect.absolute(base, rel);
+            expect(abs).to.eql('https://localhost:8080/hoot-services');
+        });
+    });
+});

--- a/test/spec/util/detect.js
+++ b/test/spec/util/detect.js
@@ -1,5 +1,5 @@
 describe('iD.detect', function() {
-    var detect = iD.utilDetect();
+    var detect = iD.Detect();
     describe('absolute', function() {
         it('get the absolute url for dev webpack', function() {
             var base = 'https://localhost:8080/';
@@ -11,13 +11,13 @@ describe('iD.detect', function() {
             var base = 'https://localhost:8443/hootenanny-id/';
             var rel = '../hoot-services';
             var abs = detect.absolute(base, rel);
-            expect(abs).to.eql('https://localhost:8080/hoot-services');
+            expect(abs).to.eql('https://localhost:8443/hoot-services');
         });
         it('get the absolute url for production', function() {
             var base = 'https://localhost/hootenanny/hootenanny-id/';
             var rel = '../hoot-services';
             var abs = detect.absolute(base, rel);
-            expect(abs).to.eql('https://localhost:8080/hoot-services');
+            expect(abs).to.eql('https://localhost/hootenanny/hoot-services');
         });
     });
 });

--- a/webpack-config/webpack.development.config.js
+++ b/webpack-config/webpack.development.config.js
@@ -13,7 +13,7 @@ module.exports = merge( CommonConfig, {
     devtool: 'cheap-module-source-map',
     devServer: {
         compress: true,
-        https: true,
+        server: 'https',
         port: 8080,
         static: {
             directory: path.join(__dirname, '../dist'),


### PR DESCRIPTION
fixes bug where url sent to JOSM included a `../` which isn't handled in java the way it is in browsers or javascript, ended up in a malformed url error when sent back to Hoot.