### PR TITLE
Override max node count

### DIFF
--- a/dist/globals.js
+++ b/dist/globals.js
@@ -1,3 +1,4 @@
 var tm4ApiUrl,
     translationServerPort,
-    mergeServerPort;
+    mergeServerPort,
+    globalMaxNodeCount;

--- a/modules/Hoot/config/apiConfig.js
+++ b/modules/Hoot/config/apiConfig.js
@@ -26,10 +26,12 @@ export const apiConfig = {
     /* eslint-enable no-undef */
     queryInterval: 2000,
     runTasksInterval: 90000,
-    rateLimit: 20 //supports 20 concurrent file uploads or deletes
+    rateLimit: 20, //supports 20 concurrent file uploads or deletes
+    maxNodeCount: globalMaxNodeCount || 20000
 };
 
 export default apiConfig;
 
 export let baseUrl = `${apiConfig.path}`;
 export let rateLimit = apiConfig.rateLimit;
+export let maxNodeCount = apiConfig.maxNodeCount;

--- a/modules/Hoot/config/apiConfig.js
+++ b/modules/Hoot/config/apiConfig.js
@@ -23,11 +23,11 @@ export const apiConfig = {
     tm4ApiUrl: tm4ApiUrl || '/tm4api',
     translationServerPort: translationServerPort || '8094',
     mergeServerPort: mergeServerPort || '8096',
+    maxNodeCount: globalMaxNodeCount || 20000,
     /* eslint-enable no-undef */
     queryInterval: 2000,
     runTasksInterval: 90000,
-    rateLimit: 20, //supports 20 concurrent file uploads or deletes
-    maxNodeCount: globalMaxNodeCount || 20000
+    rateLimit: 20 //supports 20 concurrent file uploads or deletes
 };
 
 export default apiConfig;

--- a/modules/Hoot/ui/modals/ImportMultiDatasets.js
+++ b/modules/Hoot/ui/modals/ImportMultiDatasets.js
@@ -262,15 +262,16 @@ export default class ImportMultiDatasets {
             }
         }
 
-        if ( totalFileSize > ingestThreshold ) {
-            let thresholdInMb = Math.floor( ingestThreshold / 1000000 );
+        // Disable warning about import file size
+        // if ( totalFileSize > ingestThreshold ) {
+        //     let thresholdInMb = Math.floor( ingestThreshold / 1000000 );
 
-            let message = `The total size of ingested files are greater than ingest threshold size of ${ thresholdInMb } MB and it may have problem. Do you wish to continue?`;
+        //     let message = `The total size of ingested files are greater than ingest threshold size of ${ thresholdInMb } MB and it may have problem. Do you wish to continue?`;
 
-            return Hoot.message.confirm( message );
-        } else {
-            return true;
-        }
+        //     return Hoot.message.confirm( message );
+        // } else {
+        //     return true;
+        // }
     }
 
     /**

--- a/modules/Hoot/ui/modals/importDataset.js
+++ b/modules/Hoot/ui/modals/importDataset.js
@@ -326,15 +326,16 @@ export default class ImportDataset {
             }
         }
 
-        if ( totalFileSize > ingestThreshold ) {
-            let thresholdInMb = Math.floor( ingestThreshold / 1000000 );
+        // Disable warning about import file size
+        // if ( totalFileSize > ingestThreshold ) {
+        //     let thresholdInMb = Math.floor( ingestThreshold / 1000000 );
 
-            let message = `The total size of ingested files are greater than ingest threshold size of ${ thresholdInMb } MB and it may have problem. Do you wish to continue?`;
+        //     let message = `The total size of ingested files are greater than ingest threshold size of ${ thresholdInMb } MB and it may have problem. Do you wish to continue?`;
 
-            return Hoot.message.confirm( message );
-        } else {
-            return true;
-        }
+        //     return Hoot.message.confirm( message );
+        // } else {
+        //     return true;
+        // }
     }
 
     /**

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -38,7 +38,7 @@ import {
     utilQsString
 } from '../util';
 
-import { baseUrl as hootBaseUrl } from '../Hoot/config/apiConfig';
+import { baseUrl as hootBaseUrl, maxNodeCount } from '../Hoot/config/apiConfig';
 
 var tiler = utilTiler();
 var dispatch = d3_dispatch('authLoading', 'authDone', 'change', 'loading', 'loaded', 'loadedNotes');
@@ -77,7 +77,7 @@ var _rateLimitError;
 var _userChangesets;
 var _userDetails;
 var _off;
-var _maxNodeCount = 50000;
+var _maxNodeCount = maxNodeCount;
 
 
 function authLoading() {


### PR DESCRIPTION
The app has locked up trying to fetch/render 50k worth of nodes.  Not sure what the sweet spot is but reduce the default to 20k and make it overrideable in global.js.

This PR also disables the warning when importing data files over 200mb.