### PR TITLE
Translated tagging fixes

### DIFF
--- a/modules/Hoot/managers/translationManager.js
+++ b/modules/Hoot/managers/translationManager.js
@@ -193,6 +193,44 @@ export default class TranslationManager {
         return tags;
     }
 
+    decodeSchemaKey( key ) {
+        let decodeKey = key;
+        if (this.activeSchema) {
+            const keys = this.activeSchema.columns.filter(function(d) {
+                return d.name === key.toUpperCase();
+            }).map(function(d) {
+                return d.desc;
+            });
+            if (keys.length) {
+                decodeKey = keys[0];
+            }
+        }
+        return decodeKey;
+    }
+
+    decodeSchemaValue( tag ) {
+        let decodeValue;
+        if (this.activeSchema) {
+            let values = [];
+            let columns = this.activeSchema.columns.filter(function(d) {
+                return d.name === tag.key.toUpperCase();
+            });
+            if (columns.length === 1) {
+                if (columns[0].enumerations) {
+                    values = columns[0].enumerations.filter(function(d) {
+                        return d.value === tag.value;
+                    }).map(function(d) {
+                        return d.name;
+                    });
+                }
+            }
+            if (values.length) {
+                decodeValue = values[0];
+            }
+        }
+        return decodeValue;
+    }
+
     filterSchemaKeys( value ) {
         return _map( _filter( this.activeSchema.columns, d => {
             return d.name.startsWith( value.toUpperCase() );

--- a/modules/ui/preset_editor.js
+++ b/modules/ui/preset_editor.js
@@ -53,13 +53,15 @@ export function uiPresetEditor(context) {
                 );
             }
 
-            presets.universal().forEach(function(field) {
-                if (_preset.fields.indexOf(field) === -1) {
-                    _fieldsArr.push(
-                        uiField(context, field, entity, { show: false })
-                    );
-                }
-            });
+            if (Hoot.translations.activeTranslation == 'OSM') {
+                presets.universal().forEach(function(field) {
+                    if (_preset.fields.indexOf(field) === -1) {
+                        _fieldsArr.push(
+                            uiField(context, field, entity, { show: false })
+                        );
+                    }
+                });
+            }
 
             _fieldsArr.forEach(function(field) {
                 field

--- a/modules/ui/preset_editor.js
+++ b/modules/ui/preset_editor.js
@@ -53,7 +53,7 @@ export function uiPresetEditor(context) {
                 );
             }
 
-            if (Hoot.translations.activeTranslation == 'OSM') {
+            if (Hoot.translations.activeTranslation === 'OSM') {
                 presets.universal().forEach(function(field) {
                     if (_preset.fields.indexOf(field) === -1) {
                         _fieldsArr.push(

--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -206,12 +206,17 @@ export function uiRawTagEditor(context) {
             });
 
         items.selectAll('input.key')
-            .attr('title', function(d) { return d.key; })
+            .attr('title', function(d) { return Hoot.translations.decodeSchemaKey(d.key); })
             .call(utilGetSetValue, function(d) { return d.key; })
             .property('disabled', isReadOnly);
 
         items.selectAll('input.value')
-            .attr('title', function(d) { return d.value; })
+            .attr('title', function(d) {
+                // when multi-value, show new line delimited so you can see each value
+                // when translated w/enumerated value, get title of enumerated value
+                // all other cases what's in the input has all the info user needs.
+                return Array.isArray(d.value) ? d.value.filter(Boolean).join('\n') : Hoot.translations.decodeSchemaValue(d);
+            })
             .call(utilGetSetValue, function(d) { return d.value; })
             .property('disabled', isReadOnly);
 

--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -255,7 +255,10 @@ export function uiRawTagEditor(context) {
                             if (!err) callback(sort(value, data));
                         });
                     } else {
-                        var data = Hoot.translations.filterSchemaKeys(value);
+                        var keys = Object.keys(_tags);
+                        var data = Hoot.translations.filterSchemaKeys(value).filter((d) =>
+                            keys.indexOf(d.value) === -1
+                        );
                         callback(sort(value, data));
                     }
                 }));


### PR DESCRIPTION
- make raw tag editor ignore translated keys for fcode that are already in tags returned from translation server
- make raw tag editor show descriptions for keys and enumerated values when viewing translated features
- only append 'universal presets' when schema is osm