### PR TITLE
Update About version to include commit date

### DIFF
--- a/modules/Hoot/config/buildInfo.json
+++ b/modules/Hoot/config/buildInfo.json
@@ -1,1 +1,1 @@
-{"name": "Hootenanny iD Editor", "version": "v2.12.1-1114-g7dddd1ebf", "user": "webpack"}
+{"name": "UI", "version": "v2.12.1-1115-g01af7a531", "date": "2023-03-22", "user": "webpack"}

--- a/modules/Hoot/config/domMetadata.js
+++ b/modules/Hoot/config/domMetadata.js
@@ -601,8 +601,8 @@ export function basemapAddForm() {
 export function aboutForm() {
     return [
         {
-            label: 'Main Version',
-            id: 'aboutMainVersion',
+            label: 'Versions',
+            id: 'aboutVersions',
             inputType: 'custom',
             createCustom: field => this.createTableFieldset( field )
         }

--- a/modules/Hoot/ui/about.js
+++ b/modules/Hoot/ui/about.js
@@ -48,7 +48,7 @@ export default class About {
             .text( d => {
                 let builtBy = d.builtBy || d.user;
 
-                return `${ d.name } - Version: ${ d.version } - Built By: ${ builtBy }`;
+                return `${ d.name } ${ d.version } (${d.date}) built by ${ builtBy }`;
             } );
     }
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "testgui:hoot": "karma start karma.conf.js --single-run --browsers Chrome",
     "test:spec": "karma start karma.id.conf.js",
     "translations": "node data/update_locales",
-    "buildinfo": "UI_VERSION=`git describe --tags` && echo '{\"name\": \"Hootenanny iD Editor\", \"version\": \"'$UI_VERSION'\", \"user\": \"webpack\"}' > modules/Hoot/config/buildInfo.json"
+    "buildinfo": "UI_VERSION=`git describe --tags` && UI_VERSION_DATE=`git show -s --format=%cs` && echo '{\"name\": \"UI\", \"version\": \"'$UI_VERSION'\", \"date\": \"'$UI_VERSION_DATE'\", \"user\": \"webpack\"}' > modules/Hoot/config/buildInfo.json"
   },
   "dependencies": {
     "@mapbox/sexagesimal": "1.2.0",


### PR DESCRIPTION
fixes #1359

This changes the format of the About popup from:

![versionold](https://user-images.githubusercontent.com/2600932/227645484-f8b6c93b-f2dc-47c0-9efb-38249ad7775e.png)


to:

![version](https://user-images.githubusercontent.com/2600932/227645378-98e227a6-5ac5-4b3b-ad88-93f860cd0655.png)
