### PR TITLE
update node-sass version for nodejs update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10332,7 +10332,7 @@
     "node-sass": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-6.0.1.tgz",
-      "integrity": "sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==",
+      "integrity": "sha512-f+Rbqt92Ful9gX0cGtdYwjTrWAaGURgaK5rZCWOgCNyGWusFYHhbqCCBoFBeat+HKETOU02AyTxNhJV0YZf2jQ==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5377,8 +5377,8 @@
       }
     },
     "editor-layer-index": {
-      "version": "github:osmlab/editor-layer-index#6d45bfa5efef133f4eba6f1ef6bf85cc4c74f48d",
-      "from": "github:osmlab/editor-layer-index#gh-pages",
+      "version": "git+https://git@github.com/osmlab/editor-layer-index.git#8f54587bfbbcf956ade901e32a17eb0a04a7a354",
+      "from": "git+https://git@github.com/osmlab/editor-layer-index.git#gh-pages",
       "dev": true
     },
     "ee-first": {
@@ -10330,8 +10330,8 @@
       "dev": true
     },
     "node-sass": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.1.tgz",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-6.0.1.tgz",
       "integrity": "sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "minimist": "^1.2.6",
     "mocha": "^9.2.0",
     "name-suggestion-index": "6.0.20211117",
-    "node-sass": "^7.0.1",
+    "node-sass": "^6.0.1",
     "npm-run-all": "^4.1.5",
     "osm-community-index": "0.5.0",
     "request": "^2.88.2",


### PR DESCRIPTION
nodejs has been updated to 16, requiring node-sass version to be 6.0+